### PR TITLE
feat: 부서 전체 조회 기능 #17

### DIFF
--- a/src/main/java/com/mcn/in4/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/mcn/in4/domain/department/controller/DepartmentController.java
@@ -1,0 +1,24 @@
+package com.mcn.in4.domain.department.controller;
+
+import com.mcn.in4.domain.department.dto.response.DepartmentResponse;
+import com.mcn.in4.domain.department.service.DepartmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/departments")
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    @GetMapping
+    public ResponseEntity<List<DepartmentResponse>> getAllDepartments() {
+        return ResponseEntity.ok(departmentService.findAllDepartments());
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/department/dto/request/DepartmentRequest.java
+++ b/src/main/java/com/mcn/in4/domain/department/dto/request/DepartmentRequest.java
@@ -1,0 +1,4 @@
+package com.mcn.in4.domain.department.dto.request;
+
+public class DepartmentRequest {
+}

--- a/src/main/java/com/mcn/in4/domain/department/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/mcn/in4/domain/department/dto/response/DepartmentResponse.java
@@ -1,0 +1,26 @@
+package com.mcn.in4.domain.department.dto.response;
+
+import com.mcn.in4.domain.department.entity.Department;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DepartmentResponse {
+    private final Long departmentId;
+    private final String departmentName;
+    private final String departmentCall;
+    private final String departmentDetail;
+    private final String departmentColor;
+
+    public static DepartmentResponse from(Department department) {
+        return new DepartmentResponse(
+                department.getDepartmentId(),
+                department.getDepartmentName(),
+                department.getDepartmentCall(),
+                department.getDepartmentDetail(),
+                department.getDepartmentColor()
+        );
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/department/entity/Department.java
+++ b/src/main/java/com/mcn/in4/domain/department/entity/Department.java
@@ -1,4 +1,4 @@
-package com.mcn.in4.entity.member;
+package com.mcn.in4.domain.department.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/mcn/in4/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/mcn/in4/domain/department/repository/DepartmentRepository.java
@@ -1,0 +1,9 @@
+package com.mcn.in4.domain.department.repository;
+
+import com.mcn.in4.domain.department.entity.Department;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+}

--- a/src/main/java/com/mcn/in4/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/mcn/in4/domain/department/service/DepartmentService.java
@@ -1,0 +1,9 @@
+package com.mcn.in4.domain.department.service;
+
+import com.mcn.in4.domain.department.dto.response.DepartmentResponse;
+import java.util.List;
+
+public interface DepartmentService {
+    //전체 목록 부서 조회
+    List<DepartmentResponse> findAllDepartments();
+}

--- a/src/main/java/com/mcn/in4/domain/department/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/department/service/DepartmentServiceImpl.java
@@ -1,0 +1,26 @@
+package com.mcn.in4.domain.department.service;
+
+import com.mcn.in4.domain.department.dto.response.DepartmentResponse;
+import com.mcn.in4.domain.department.repository.DepartmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DepartmentServiceImpl implements DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+
+    @Override
+    public List<DepartmentResponse> findAllDepartments() {
+        return departmentRepository.findAll()
+                .stream()
+                .map(DepartmentResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/mcn/in4/entity/member/Member.java
+++ b/src/main/java/com/mcn/in4/entity/member/Member.java
@@ -1,5 +1,6 @@
 package com.mcn.in4.entity.member;
 
+import com.mcn.in4.domain.department.entity.Department;
 import com.mcn.in4.entity.member.memberEnum.MemberRole;
 import com.mcn.in4.entity.member.memberEnum.MemberStatus;
 import jakarta.persistence.*;
@@ -18,10 +19,12 @@ public class Member {
     private Long memberId;
     //사용자 키
 
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id", nullable = true)
     private Department department;
     //사용자 소속 부서 키 (상위 엔티티 삭제시 NULL화)
+
 
     @Column(name = "member_account", nullable = false)
     private String memberAccount;

--- a/src/main/java/com/mcn/in4/entity/member/MemberEmployeeDetail.java
+++ b/src/main/java/com/mcn/in4/entity/member/MemberEmployeeDetail.java
@@ -1,5 +1,6 @@
 package com.mcn.in4.entity.member;
 
+import com.mcn.in4.domain.department.entity.Department;
 import com.mcn.in4.entity.member.memberEnum.EmploymentType;
 import jakarta.persistence.*;
 import lombok.*;


### PR DESCRIPTION
## 관련 이슈 번호
- #17 

## 변경 내용
- 회사 부서 조회 기능 추가
- entity member의 department-id와 member-employee-detail 임시로 department entity로 변경
## 리뷰 포인트
- entity 생성 이상 없는지 확인

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수