### PR TITLE
feat : 부서 추가,수정,삭제 기능 추가 #45

### DIFF
--- a/src/main/java/com/mcn/in4/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/mcn/in4/domain/department/controller/DepartmentController.java
@@ -1,24 +1,47 @@
 package com.mcn.in4.domain.department.controller;
 
+import com.mcn.in4.domain.department.dto.request.DepartmentRequest;
 import com.mcn.in4.domain.department.dto.response.DepartmentResponse;
 import com.mcn.in4.domain.department.service.DepartmentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/departments")
+@RequestMapping("/api")
 public class DepartmentController {
 
     private final DepartmentService departmentService;
 
-    @GetMapping
+    // 전체 조회
+    @GetMapping("/departments")
     public ResponseEntity<List<DepartmentResponse>> getAllDepartments() {
         return ResponseEntity.ok(departmentService.findAllDepartments());
+    }
+
+    // 부서 추가
+    @PostMapping("/departments")
+    public ResponseEntity<Void> createDepartment(@RequestBody DepartmentRequest request) {
+        departmentService.createDepartment(request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 부서 상세 수정
+    @PatchMapping("/department/{id}")
+    public ResponseEntity<Void> updateDepartment(
+            @PathVariable Long id,
+            @RequestBody DepartmentRequest request) {
+        departmentService.updateDepartment(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 부서 삭제
+    @DeleteMapping("/department/{id}")
+    public ResponseEntity<Void> deleteDepartment(@PathVariable Long id) {
+        departmentService.deleteDepartment(id);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
 }

--- a/src/main/java/com/mcn/in4/domain/department/dto/request/DepartmentRequest.java
+++ b/src/main/java/com/mcn/in4/domain/department/dto/request/DepartmentRequest.java
@@ -1,4 +1,13 @@
 package com.mcn.in4.domain.department.dto.request;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class DepartmentRequest {
+    private String departmentName;
+    private String departmentCall;
+    private String departmentDetail;
+    private String departmentColor;
 }

--- a/src/main/java/com/mcn/in4/domain/department/entity/Department.java
+++ b/src/main/java/com/mcn/in4/domain/department/entity/Department.java
@@ -31,4 +31,11 @@ public class Department {
 
     @Column(name = "department_color", nullable = false)
     private String departmentColor;
+    
+    public void update(String name, String call, String detail, String color) {
+        this.departmentName = name;
+        this.departmentCall = call;
+        this.departmentDetail = detail;
+        this.departmentColor = color;
+    }
 }

--- a/src/main/java/com/mcn/in4/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/mcn/in4/domain/department/service/DepartmentService.java
@@ -1,9 +1,12 @@
 package com.mcn.in4.domain.department.service;
 
+import com.mcn.in4.domain.department.dto.request.DepartmentRequest;
 import com.mcn.in4.domain.department.dto.response.DepartmentResponse;
 import java.util.List;
 
 public interface DepartmentService {
-    //전체 목록 부서 조회
     List<DepartmentResponse> findAllDepartments();
+    void createDepartment(DepartmentRequest request); // 추가
+    void updateDepartment(Long id, DepartmentRequest request); // 추가
+    void deleteDepartment(Long id); // 추가
 }

--- a/src/main/java/com/mcn/in4/domain/department/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/department/service/DepartmentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.mcn.in4.domain.department.service;
 
+import com.mcn.in4.domain.department.dto.request.DepartmentRequest;
 import com.mcn.in4.domain.department.dto.response.DepartmentResponse;
+import com.mcn.in4.domain.department.entity.Department;
 import com.mcn.in4.domain.department.repository.DepartmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,16 +13,48 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public List<DepartmentResponse> findAllDepartments() {
-        return departmentRepository.findAll()
-                .stream()
+        return departmentRepository.findAll().stream()
                 .map(DepartmentResponse::from)
                 .toList();
+    }
+
+    @Override
+    public void createDepartment(DepartmentRequest request) {
+        Department department = new Department(
+                null, // IDENTITY 전략이므로 null 전달
+                request.getDepartmentName(),
+                request.getDepartmentCall(),
+                request.getDepartmentDetail(),
+                request.getDepartmentColor()
+        );
+        departmentRepository.save(department);
+    }
+
+    @Override
+    public void updateDepartment(Long id, DepartmentRequest request) {
+        Department department = departmentRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 부서가 존재하지 않습니다. id=" + id));
+
+        department.update(
+                request.getDepartmentName(),
+                request.getDepartmentCall(),
+                request.getDepartmentDetail(),
+                request.getDepartmentColor()
+        );
+    }
+
+    @Override
+    public void deleteDepartment(Long id) {
+        Department department = departmentRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 부서가 존재하지 않습니다. id=" + id));
+        departmentRepository.delete(department);
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
#45 


## 변경 내용
- post를 활용한 부서 추가 기능
- patch를 사용한 부서 정보 수정 기능
- delete를 사용한 부서 삭제

## 리뷰 포인트
부서 추가,수정,삭제 후 조회해서 잘 반영되는지 확인

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ v] 빌드/컴파일 정상
- [ v] 로컬 테스트 완료
- [ v] 불필요 코드 제거
- [ v] 브랜치 전략 준수