### PR TITLE
feat: all employee attendance dashboard

### DIFF
--- a/src/main/java/com/mcn/in4/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/mcn/in4/domain/attendance/controller/AttendanceController.java
@@ -2,6 +2,7 @@ package com.mcn.in4.domain.attendance.controller;
 
 import com.mcn.in4.domain.attendance.dto.AttendanceResponseDto;
 import com.mcn.in4.domain.attendance.dto.AttendanceDashboardDto;
+import com.mcn.in4.domain.attendance.dto.CompanyAttendanceDashboardDto;
 import com.mcn.in4.domain.attendance.service.AttendanceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -83,6 +84,27 @@ public class AttendanceController {
 
         Long memberId = Long.parseLong(userId);
         return ResponseEntity.ok(attendanceService.getMyDashboardStats(memberId));
+    }
+
+    /**
+     * 전사 근태 통계 조회 (관리자용)
+     * 전사 평균 출퇴근/근무 시간 및 오늘 근태 현황을 반환합니다.
+     * 관리자 권한이 필요합니다.
+     *
+     * @param authentication 인증 정보
+     * @return 전사 대시보드 통계 DTO
+     */
+    @GetMapping("/dashboard/company")
+    public ResponseEntity<CompanyAttendanceDashboardDto> getCompanyDashboardStats(Authentication authentication) {
+        boolean isAdmin = authentication.getAuthorities().stream()
+                .anyMatch(
+                        a -> a.getAuthority().equals("ROLE_ADMINISTRATOR"));
+
+        if (!isAdmin) {
+            return ResponseEntity.status(403).body(null);
+        }
+
+        return ResponseEntity.ok(attendanceService.getCompanyDashboardStats());
     }
 
     /**

--- a/src/main/java/com/mcn/in4/domain/attendance/dto/CompanyAttendanceDashboardDto.java
+++ b/src/main/java/com/mcn/in4/domain/attendance/dto/CompanyAttendanceDashboardDto.java
@@ -1,0 +1,20 @@
+package com.mcn.in4.domain.attendance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+/**
+ * 전사 근태 대시보드 DTO
+ * 전사 평균 출퇴근 시간 및 오늘 근태 현황을 포함합니다.
+ */
+public class CompanyAttendanceDashboardDto {
+    private String averageStartTime; // 평균 출근 시간 (09:00)
+    private String averageEndTime; // 평균 퇴근 시간 (18:00)
+    private String averageWorkTime; // 평균 근무 시간 (9h 00m)
+
+    private int todayNormalCount; // 오늘 정상 출근 수
+    private int todayLateCount; // 오늘 지각 수
+    private int todayAbsentCount; // 오늘 결근 수
+}

--- a/src/main/java/com/mcn/in4/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/mcn/in4/domain/attendance/service/AttendanceService.java
@@ -2,6 +2,7 @@ package com.mcn.in4.domain.attendance.service;
 
 import com.mcn.in4.domain.attendance.dto.AttendanceResponseDto;
 import com.mcn.in4.domain.attendance.dto.AttendanceDashboardDto;
+import com.mcn.in4.domain.attendance.dto.CompanyAttendanceDashboardDto;
 
 import java.util.List;
 import java.time.LocalDate;
@@ -56,4 +57,12 @@ public interface AttendanceService {
          * @return 대시보드 통계 DTO
          */
         AttendanceDashboardDto getMyDashboardStats(Long memberId);
+
+        /**
+         * 전사 근태 통계 조회
+         * 전사 평균 출퇴근/근무 시간 및 오늘 근태 현황을 조회합니다.
+         *
+         * @return 전사 대시보드 통계 DTO
+         */
+        CompanyAttendanceDashboardDto getCompanyDashboardStats();
 }

--- a/src/main/java/com/mcn/in4/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/attendance/service/AttendanceServiceImpl.java
@@ -1,12 +1,14 @@
 package com.mcn.in4.domain.attendance.service;
 
 import com.mcn.in4.domain.attendance.dto.AttendanceResponseDto;
-import com.mcn.in4.domain.attendance.dto.AttendanceResponseDto;
 import com.mcn.in4.domain.attendance.dto.AttendanceDashboardDto;
+import com.mcn.in4.domain.attendance.dto.CompanyAttendanceDashboardDto;
 import com.mcn.in4.domain.attendance.entity.Attendance;
 import com.mcn.in4.domain.attendance.entity.attendanceEnum.AttendanceStatus;
 import com.mcn.in4.domain.attendance.repository.AttendanceRepository;
 import com.mcn.in4.domain.member.entity.Member;
+import com.mcn.in4.domain.member.entity.memberEnum.MemberRole;
+import com.mcn.in4.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,7 @@ import java.util.stream.Collectors;
 public class AttendanceServiceImpl implements AttendanceService {
 
     private final AttendanceRepository attendanceRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public List<AttendanceResponseDto> getAttendance(Long memberId, LocalDate startDate, LocalDate endDate,
@@ -183,5 +186,100 @@ public class AttendanceServiceImpl implements AttendanceService {
                 .lateCount(lateCount)
                 .totalOvertimeMinutes(totalOvertimeMinutes)
                 .build();
+    }
+
+    @Override
+    public CompanyAttendanceDashboardDto getCompanyDashboardStats() {
+        // 1. 전체 직원 수 조회 (크리에이터 제외)
+        long totalEmployees = memberRepository.countByMemberRoleNot(MemberRole.CREATOR);
+
+        // 2. 오늘 근태 현황 조회
+        LocalDate today = LocalDate.now();
+        List<Attendance> todayAttendances = attendanceRepository.findAllByAttendanceDate(today);
+
+        // 크리에이터 제외하고 필터링
+        List<Attendance> validTodayAttendances = todayAttendances.stream()
+                .filter(a -> a.getMember().getMemberRole() != MemberRole.CREATOR)
+                .collect(Collectors.toList());
+
+        int todayNormalCount = 0;
+        int todayLateCount = 0;
+
+        for (Attendance att : validTodayAttendances) {
+            AttendanceStatus status = att.getAttendanceStatus();
+            if (status == AttendanceStatus.NORMAL || status == AttendanceStatus.WORKING) {
+                todayNormalCount++;
+            } else if (status == AttendanceStatus.LATE) {
+                todayLateCount++;
+            }
+        }
+
+        // 결근 수 = 전체 직원 수 - 오늘 출근 기록이 있는 직원 수
+        // (가정: 출근 기록이 있으면 일단 '출근'으로 간주. 휴가자 처리는 별도 로직이 필요할 수 있으나 현재 요구사항에서는 미포함)
+        int todayAbsentCount = (int) totalEmployees - validTodayAttendances.size();
+        if (todayAbsentCount < 0)
+            todayAbsentCount = 0; // 예외 처리
+
+        // 3. 이번 달 평균 시간 계산
+        LocalDate startOfMonth = today.withDayOfMonth(1);
+        LocalDate endOfMonth = today.withDayOfMonth(today.lengthOfMonth());
+        List<Attendance> monthAttendances = attendanceRepository.findAllAttendance(startOfMonth, endOfMonth, null);
+
+        // 크리에이터 제외
+        List<Attendance> validMonthAttendances = monthAttendances.stream()
+                .filter(a -> a.getMember().getMemberRole() != MemberRole.CREATOR)
+                .collect(Collectors.toList());
+
+        long totalStartMinutes = 0;
+        int startCount = 0;
+        long totalEndMinutes = 0;
+        int endCount = 0;
+        long totalWorkMinutes = 0;
+        int workCount = 0;
+
+        for (Attendance att : validMonthAttendances) {
+            // 출근 시간 평균
+            if (att.getAttendanceStart() != null) {
+                totalStartMinutes += att.getAttendanceStart().toLocalTime().toSecondOfDay() / 60;
+                startCount++;
+            }
+            // 퇴근 시간 평균
+            if (att.getAttendanceEnd() != null) {
+                totalEndMinutes += att.getAttendanceEnd().toLocalTime().toSecondOfDay() / 60;
+                endCount++;
+
+                // 근무 시간 평균
+                Duration duration = Duration.between(att.getAttendanceStart(), att.getAttendanceEnd());
+                totalWorkMinutes += duration.toMinutes();
+                workCount++;
+            }
+        }
+
+        String avgStartTime = (startCount > 0) ? formatMinutesToTime(totalStartMinutes / startCount) : "00:00";
+        String avgEndTime = (endCount > 0) ? formatMinutesToTime(totalEndMinutes / endCount) : "00:00";
+        String avgWorkTime = (workCount > 0) ? formatMinutesToDuration(totalWorkMinutes / workCount) : "0h 0m";
+
+        return CompanyAttendanceDashboardDto.builder()
+                .averageStartTime(avgStartTime)
+                .averageEndTime(avgEndTime)
+                .averageWorkTime(avgWorkTime)
+                .todayNormalCount(todayNormalCount)
+                .todayLateCount(todayLateCount)
+                .todayAbsentCount(todayAbsentCount)
+                .build();
+    }
+
+    // 분(Minute)을 "HH:mm" 형식으로 변환
+    private String formatMinutesToTime(long totalMinutes) {
+        long hours = totalMinutes / 60;
+        long minutes = totalMinutes % 60;
+        return String.format("%02d:%02d", hours, minutes);
+    }
+
+    // 분(Minute)을 "Ah Bm" 형식으로 변환
+    private String formatMinutesToDuration(long totalMinutes) {
+        long hours = totalMinutes / 60;
+        long minutes = totalMinutes % 60;
+        return String.format("%dh %02dm", hours, minutes);
     }
 }

--- a/src/main/java/com/mcn/in4/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mcn/in4/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.mcn.in4.domain.member.repository;
 
 import com.mcn.in4.domain.member.entity.Member;
+import com.mcn.in4.domain.member.entity.memberEnum.MemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -19,4 +20,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findByDepartment_DepartmentId(Long departmentId);
 
     List<Member> findAllById(Iterable<Long> ids);
+
+    long countByMemberRoleNot(MemberRole memberRole);
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #74 


## 변경 내용
- 직원 관리 대시보드 6개 구현
- 관리자만 조회 가능

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수