### PR TITLE
feat : vacation-sick-leave-monthly-dashboard #78

### DIFF
--- a/src/main/java/com/mcn/in4/domain/vacation/controller/VacationAdminController.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/controller/VacationAdminController.java
@@ -2,6 +2,7 @@ package com.mcn.in4.domain.vacation.controller;
 
 import com.mcn.in4.domain.vacation.dto.request.VacationRejectRequestDTO;
 import com.mcn.in4.domain.vacation.dto.response.AdminVacationListResponseDTO;
+import com.mcn.in4.domain.vacation.dto.response.VacationStatisticsResponseDTO;
 import com.mcn.in4.domain.vacation.entity.enums.VacationApprove;
 import com.mcn.in4.domain.vacation.service.VacationAdminService;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 /**
  * 휴가 관리 API 컨트롤러 (관리자용)
  * - GET /api/admin/vacations : 전체 휴가 목록 조회 (필터: 기간, 상태, 이름)
+ * - GET /api/admin/vacations/statistics : 휴가 통계 조회
  * - PATCH /api/admin/vacations/{id}/approve : 휴가 승인
  * - PATCH /api/admin/vacations/{id}/reject : 휴가 반려
  */
@@ -45,6 +47,16 @@ public class VacationAdminController {
         }
 
         List<AdminVacationListResponseDTO> response = vacationAdminService.getVacationList(startDate, endDate, status, name);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 휴가 통계 조회
+     * GET /api/admin/vacations/statistics
+     */
+    @GetMapping("/statistics")
+    public ResponseEntity<VacationStatisticsResponseDTO> getVacationStatistics() {
+        VacationStatisticsResponseDTO response = vacationAdminService.getVacationStatistics();
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/mcn/in4/domain/vacation/dto/response/VacationStatisticsResponseDTO.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/dto/response/VacationStatisticsResponseDTO.java
@@ -1,0 +1,40 @@
+package com.mcn.in4.domain.vacation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 휴가 통계 응답 DTO (관리자용)
+ * - 이번달 휴가자 수, 미승인 대기자 수, 이번달 병가자 수
+ */
+@Getter
+@Builder
+public class VacationStatisticsResponseDTO {
+
+    /** 이번달 휴가자 수 (승인된 휴가) */
+    private long monthlyVacationCount;
+
+    /** 총 미승인 대기자 수 */
+    private long pendingApprovalCount;
+
+    /** 이번달 병가자 수 (승인된 병가) */
+    private long monthlySickLeaveCount;
+
+    /** 통계 기준 연월 (예: "2026-01") */
+    private String targetMonth;
+
+    /** 통계 DTO 생성 */
+    public static VacationStatisticsResponseDTO of(
+            long monthlyVacationCount,
+            long pendingApprovalCount,
+            long monthlySickLeaveCount,
+            String targetMonth
+    ) {
+        return VacationStatisticsResponseDTO.builder()
+                .monthlyVacationCount(monthlyVacationCount)
+                .pendingApprovalCount(pendingApprovalCount)
+                .monthlySickLeaveCount(monthlySickLeaveCount)
+                .targetMonth(targetMonth)
+                .build();
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
@@ -47,10 +47,38 @@ public interface VacationRepository extends JpaRepository<Vacation, Long> {
     );
 
 
-    /* 오늘 날짜가 휴가 기간 내에 있고 승인된 상태인 휴가자 수 집계 */
+    /** 오늘 날짜가 휴가 기간 내에 있고 승인된 상태인 휴가자 수 집계 */
     @Query("SELECT COUNT(v) FROM Vacation v " +
             "WHERE v.vacationApprove = :approveStatus " +
             "AND :today BETWEEN v.vacationStart AND v.vacationEnd")
     long countActiveVacations(@Param("today") LocalDate today,
                               @Param("approveStatus") VacationApprove approveStatus);
+
+    /** 이번달 휴가자 수 (승인된 휴가 중 휴가 기간이 해당 월과 겹치는 건수) */
+    @Query("SELECT COUNT(v) FROM Vacation v " +
+           "WHERE v.vacationApprove = :status " +
+           "AND v.vacationStart <= :monthEnd " +
+           "AND v.vacationEnd >= :monthStart")
+    long countMonthlyVacations(
+            @Param("monthStart") LocalDate monthStart,
+            @Param("monthEnd") LocalDate monthEnd,
+            @Param("status") VacationApprove status
+    );
+
+    /** 총 미승인 대기자 수 */
+    @Query("SELECT COUNT(v) FROM Vacation v WHERE v.vacationApprove = :status")
+    long countByApproveStatus(@Param("status") VacationApprove status);
+
+    /** 이번달 병가자 수 (승인된 병가 중 휴가 기간이 해당 월과 겹치는 건수) */
+    @Query("SELECT COUNT(v) FROM Vacation v " +
+           "WHERE v.vacationType = :type " +
+           "AND v.vacationApprove = :status " +
+           "AND v.vacationStart <= :monthEnd " +
+           "AND v.vacationEnd >= :monthStart")
+    long countMonthlyByType(
+            @Param("monthStart") LocalDate monthStart,
+            @Param("monthEnd") LocalDate monthEnd,
+            @Param("type") VacationType type,
+            @Param("status") VacationApprove status
+    );
 }

--- a/src/main/java/com/mcn/in4/domain/vacation/service/VacationAdminService.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/service/VacationAdminService.java
@@ -1,6 +1,7 @@
 package com.mcn.in4.domain.vacation.service;
 
 import com.mcn.in4.domain.vacation.dto.response.AdminVacationListResponseDTO;
+import com.mcn.in4.domain.vacation.dto.response.VacationStatisticsResponseDTO;
 import com.mcn.in4.domain.vacation.entity.enums.VacationApprove;
 
 import java.time.LocalDate;
@@ -39,4 +40,10 @@ public interface VacationAdminService {
      * @param rejectReason 반려 사유
      */
     void rejectVacation(Long vacationId, String rejectReason);
+
+    /**
+     * 휴가 통계 조회
+     * @return 이번달 휴가자 수, 미승인 대기자 수, 이번달 병가자 수
+     */
+    VacationStatisticsResponseDTO getVacationStatistics();
 }

--- a/src/main/java/com/mcn/in4/domain/vacation/service/VacationAdminServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/service/VacationAdminServiceImpl.java
@@ -3,6 +3,7 @@ package com.mcn.in4.domain.vacation.service;
 import com.mcn.in4.domain.member.entity.MemberEmployeeDetail;
 import com.mcn.in4.domain.member.repository.MemberEmployeeDetailRepository;
 import com.mcn.in4.domain.vacation.dto.response.AdminVacationListResponseDTO;
+import com.mcn.in4.domain.vacation.dto.response.VacationStatisticsResponseDTO;
 import com.mcn.in4.domain.vacation.entity.Vacation;
 import com.mcn.in4.domain.vacation.entity.enums.VacationApprove;
 import com.mcn.in4.domain.vacation.entity.enums.VacationType;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,8 +44,8 @@ public class VacationAdminServiceImpl implements VacationAdminService {
                     // 잔여 연차 조회
                     Double remainder = memberEmployeeDetailRepository
                             .findByMemberMemberId(vacation.getMember().getMemberId())
-                            .map(MemberEmployeeDetail::getVacationRemainder)
-                            .orElse(0.0);
+                            .map(MemberEmployeeDetail::getVacationRemainder)// 값이 있으면 : double(12.0), 없으면 : empty
+                            .orElse(0.0); //값이 있으면 12.0, 없으면 0.0
                     return AdminVacationListResponseDTO.from(vacation, remainder);
                 })
                 .collect(Collectors.toList());
@@ -85,5 +87,32 @@ public class VacationAdminServiceImpl implements VacationAdminService {
         }
 
         vacation.reject(rejectReason);
+    }
+
+    /** 휴가 통계 조회 (이번달 휴가자, 미승인 대기자, 이번달 병가자) */
+    @Override
+    public VacationStatisticsResponseDTO getVacationStatistics() {
+        // 이번달 기준 날짜 계산
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate monthStart = currentMonth.atDay(1);
+        LocalDate monthEnd = currentMonth.atEndOfMonth();
+
+        // 1. 이번달 휴가자 수 (승인된 휴가)
+        long monthlyVacationCount = vacationRepository.countMonthlyVacations(
+                monthStart, monthEnd, VacationApprove.APPROVED);
+
+        // 2. 총 미승인 대기자 수
+        long pendingApprovalCount = vacationRepository.countByApproveStatus(VacationApprove.APPROVE_NEED);
+
+        // 3. 이번달 병가자 수 (승인된 병가)
+        long monthlySickLeaveCount = vacationRepository.countMonthlyByType(
+                monthStart, monthEnd, VacationType.SICK, VacationApprove.APPROVED);
+
+        return VacationStatisticsResponseDTO.of(
+                monthlyVacationCount,
+                pendingApprovalCount,
+                monthlySickLeaveCount,
+                currentMonth.toString()
+        );
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #


## 변경 내용
- 예)Trade 서비스 분리 대비: 직접 참조 제거 및 Client 패턴 적용
- 예)SettlementService에서 Trade(SellingBid) 의존성 제거
- 예)Settlement에 sellerId 추가(조회 최적화), Order의 seller 정보 활용 리팩토링

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수