### PR TITLE
fix: PATCH 허용 추가

### DIFF
--- a/src/main/java/com/mcn/in4/global/config/SecurityConfig.java
+++ b/src/main/java/com/mcn/in4/global/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
-        corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         corsConfiguration.addAllowedHeader("*");
         corsConfiguration.setAllowCredentials(true); //인증정보를 포함한 cors요청 허용
         corsConfiguration.setMaxAge(3600L); //1시간


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #94 


## 변경 내용
- security config에 PATCH를 제외한 모든 cors 설정이 되어있음. 프론트에서 patch가 수행되지 않는 문제 발견 후 추가
corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"))