### PR TITLE
feat: add automatic annual leave reset on January 1st

### DIFF
--- a/src/main/java/com/mcn/in4/In4Application.java
+++ b/src/main/java/com/mcn/in4/In4Application.java
@@ -2,8 +2,10 @@ package com.mcn.in4;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class In4Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mcn/in4/domain/member/entity/MemberEmployeeDetail.java
+++ b/src/main/java/com/mcn/in4/domain/member/entity/MemberEmployeeDetail.java
@@ -78,6 +78,10 @@ public class MemberEmployeeDetail {
         this.vacationRemainder += days;
     }
 
+    public void resetVacationRemainder() {
+        this.vacationRemainder = 15.0;
+    }
+
     //퇴사 일, 퇴사 이유
     public void markAsQuit(String empDate, String leavingReason) {
         this.empDate = empDate;

--- a/src/main/java/com/mcn/in4/domain/vacation/scheduler/VacationResetScheduler.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/scheduler/VacationResetScheduler.java
@@ -1,0 +1,31 @@
+package com.mcn.in4.domain.vacation.scheduler;
+
+import com.mcn.in4.domain.member.repository.MemberEmployeeDetailRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 연차 초기화 스케줄러
+ * - 매년 1월 1일 00:00:00에 모든 직원의 연차를 15일로 초기화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VacationResetScheduler {
+
+    private final MemberEmployeeDetailRepository memberEmployeeDetailRepository;
+
+    @Scheduled(cron = "0 0 0 1 1 *")
+    @Transactional
+    public void resetAnnualVacation() {
+        log.info("연차 초기화 스케줄러 실행 시작");
+
+        memberEmployeeDetailRepository.findAll()
+                .forEach(emp -> emp.resetVacationRemainder());
+
+        log.info("연차 초기화 스케줄러 실행 완료");
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #105


## 변경 내용
- 매년 연차 초기화
- in4Applocation.java 추가
- VacationResetScheduler.java 추가
- MemberEmployeeDetail.java 변경