### PR TITLE
fix: attendance service update

### DIFF
--- a/src/main/java/com/mcn/in4/domain/attendance/service/AttendanceServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/attendance/service/AttendanceServiceImpl.java
@@ -219,7 +219,8 @@ public class AttendanceServiceImpl implements AttendanceService {
 
         for (Attendance att : validTodayAttendances) {
             AttendanceStatus status = att.getAttendanceStatus();
-            if (status == AttendanceStatus.NORMAL || status == AttendanceStatus.WORKING) {
+            if (status == AttendanceStatus.NORMAL || status == AttendanceStatus.WORKING
+                    || status == AttendanceStatus.OVERTIME) {
                 todayNormalCount++;
             } else if (status == AttendanceStatus.LATE) {
                 todayLateCount++;


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #109 


## 변경 내용
- 대시보드의 "오늘 정상출근" 숫자 카운팅을 위한 수정
- 정상, 근무 중은 현재 정상 출근에 카운팅되지만, 초과는 카운팅이 안되므로 초과 상태도 카운팅이 되도록 수정

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수