### PR TITLE
fix: 팀 상세 정보에서 직원 출근, 휴가 상태도 조회힐 수 있도록 수정 #110

### DIFF
--- a/src/main/java/com/mcn/in4/domain/team/dto/response/TeamDetailResponse.java
+++ b/src/main/java/com/mcn/in4/domain/team/dto/response/TeamDetailResponse.java
@@ -21,5 +21,6 @@ public class TeamDetailResponse {
         private String memberName;     // Member.memberName
         private String departmentName; // Department.departmentName
         private String task;           // Member.task (직책/직무)
+        private String workStatus;     // 근무 상태 (출근, 휴가, 미출근 등)
     }
 }

--- a/src/main/java/com/mcn/in4/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/team/service/TeamServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mcn.in4.domain.team.service;
 
+import com.mcn.in4.domain.attendance.repository.AttendanceRepository;
 import com.mcn.in4.domain.member.entity.Member;
 import com.mcn.in4.domain.member.repository.MemberRepository;
 import com.mcn.in4.domain.team.dto.request.TeamCreateRequest;
@@ -11,10 +12,13 @@ import com.mcn.in4.domain.team.entity.Team;
 import com.mcn.in4.domain.team.entity.TeamRelay;
 import com.mcn.in4.domain.team.repository.TeamRelayRepository;
 import com.mcn.in4.domain.team.repository.TeamRepository;
+import com.mcn.in4.domain.vacation.entity.enums.VacationApprove;
+import com.mcn.in4.domain.vacation.repository.VacationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +32,8 @@ public class TeamServiceImpl implements TeamService {
     private final TeamRepository teamRepository;
     private final TeamRelayRepository teamRelayRepository;
     private final MemberRepository memberRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final VacationRepository vacationRepository;
 
     @Override
     public List<TeamResponse> findAllTeams() {
@@ -45,13 +51,32 @@ public class TeamServiceImpl implements TeamService {
         // 2. 소속 멤버 상세 조회 (Fetch Join 활용)
         List<TeamRelay> relays = teamRelayRepository.findAllByTeamIdWithMemberAndDept(teamId);
 
-        // 3. DTO 변환
+        // 3. DTO 변환 및 근태/휴가 상태 확인
         List<TeamDetailResponse.TeamMemberResponse> memberResponses = relays.stream()
                 .map(tr -> {
                     var m = tr.getMember();
                     String deptName = (m.getDepartment() != null) ? m.getDepartment().getDepartmentName() : "무소속";
+
+                    // 근무 상태 확인 로직 시작
+                    String workStatus = "미출근";
+                    LocalDate today = LocalDate.now();
+
+                    // 1. 휴가 여부 확인 (VacationRepository 활용)
+                    boolean isVacation = vacationRepository.isMemberOnVacation(m.getMemberId(), today, VacationApprove.APPROVED);
+
+                    if (isVacation) {
+                        workStatus = "휴가";
+                    } else {
+                        // 2. 출근 여부 확인 (AttendanceRepository 활용)
+                        var attendanceOpt = attendanceRepository.findByMemberIdAndAttendanceDate(m.getMemberId(), today);
+                        if (attendanceOpt.isPresent()) {
+                            // 출근 기록이 있으면 해당 상태(근무중, 퇴근, 지각 등)의 설명을 가져옴
+                            workStatus = attendanceOpt.get().getAttendanceStatus().getDescription();
+                        }
+                    }
+
                     return new TeamDetailResponse.TeamMemberResponse(
-                            m.getMemberId(), m.getMemberName(), deptName, m.getTask()
+                            m.getMemberId(), m.getMemberName(), deptName, m.getTask(), workStatus
                     );
                 }).toList();
 

--- a/src/main/java/com/mcn/in4/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/team/service/TeamServiceImpl.java
@@ -44,14 +44,14 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public TeamDetailResponse getTeamDetail(Long teamId) {
-        // 1. 팀 정보 조회
+        //팀 정보 조회
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 팀을 찾을 수 없습니다."));
 
-        // 2. 소속 멤버 상세 조회 (Fetch Join 활용)
+        //소속 멤버 상세 조회 (Fetch Join 활용)
         List<TeamRelay> relays = teamRelayRepository.findAllByTeamIdWithMemberAndDept(teamId);
 
-        // 3. DTO 변환 및 근태/휴가 상태 확인
+        //DTO 변환 및 근태/휴가 상태 확인
         List<TeamDetailResponse.TeamMemberResponse> memberResponses = relays.stream()
                 .map(tr -> {
                     var m = tr.getMember();
@@ -91,16 +91,16 @@ public class TeamServiceImpl implements TeamService {
     @Override
     @Transactional
     public void createTeam(TeamCreateRequest request) {
-        // 1. 팀 저장 및 즉시 반영
+        //팀 저장 및 즉시 반영
         Team team = new Team(null, request.getTeamName(), request.getTeamDetail());
         Team savedTeam = teamRepository.saveAndFlush(team);
 
-        // 2. 멤버 조회
+        //멤버 조회
         List<Member> members = memberRepository.findAllById(request.getMemberIds());
 
         if (members.isEmpty()) return;
 
-        // 3. TeamRelay 생성
+        //TeamRelay 생성
         List<TeamRelay> relays = members.stream()
                 .map(member -> {
                     // 수동 ID 부여 대신 builder나 생성자를 통해
@@ -109,28 +109,28 @@ public class TeamServiceImpl implements TeamService {
                 })
                 .toList();
 
-        // 4. 저장 및 강제 반영
+        //저장 및 강제 반영
         teamRelayRepository.saveAllAndFlush(relays);
     }
 
     @Override
     @Transactional
     public void updateTeamMembers(Long teamId, TeamMemberUpdateRequest request) {
-        // 1. 대상 팀 존재 확인
+        //대상 팀 존재 확인
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 팀을 찾을 수 없습니다."));
 
-        // 2. 기존 팀 멤버 연결(Relay) 전체 삭제
+        //기존 팀 멤버 연결(Relay) 전체 삭제
         teamRelayRepository.deleteAllByTeamId(teamId);
 
-        // 3. 새로 요청된 멤버들 조회
+        //새로 요청된 멤버들 조회
         List<Member> newMembers = memberRepository.findAllById(request.getMemberIds());
 
         if (newMembers.isEmpty()) {
             return; // 혹은 모든 멤버를 제거하는 것이 의도라면 여기서 종료
         }
 
-        // 4. 새로운 연결 데이터(Relay) 생성 및 저장
+        //새로운 연결 데이터(Relay) 생성 및 저장
         List<TeamRelay> newRelays = newMembers.stream()
                 .map(member -> new TeamRelay(null, team, member)) // ID는 자동생성(IDENTITY) 가정
                 .toList();
@@ -141,14 +141,14 @@ public class TeamServiceImpl implements TeamService {
     @Override
     @Transactional
     public void deleteTeam(Long teamId) {
-        // 1. 삭제할 팀이 존재하는지 먼저 확인
+        //삭제할 팀이 존재하는지 먼저 확인
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new IllegalArgumentException("삭제하려는 팀이 존재하지 않습니다. ID: " + teamId));
 
-        // 2. 해당 팀과 연결된 멤버 관계(TeamRelay)를 먼저 삭제 (FK 제약 조건 해결)
+        //해당 팀과 연결된 멤버 관계(TeamRelay)를 먼저 삭제 (FK 제약 조건 해결)
         teamRelayRepository.deleteAllByTeamId(teamId);
 
-        // 3. 팀 엔티티 삭제
+        //팀 엔티티 삭제
         teamRepository.delete(team);
     }
 
@@ -156,7 +156,6 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public List<MyTeamResponse> getMyTeams(String memberIdStr) {
-        // [수정] findByMemberAccount 대신 findById 사용 (토큰에 ID가 들어있음)
         Long memberId = Long.parseLong(memberIdStr);
 
         Member member = memberRepository.findById(memberId)
@@ -195,7 +194,6 @@ public class TeamServiceImpl implements TeamService {
 
     @Override
     public MyTeamResponse getMyTeamDetail(String memberIdStr, Long teamId) {
-        // [수정] 여기도 마찬가지로 ID로 찾도록 변경
         Long memberId = Long.parseLong(memberIdStr);
 
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/mcn/in4/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/team/service/TeamServiceImpl.java
@@ -61,13 +61,13 @@ public class TeamServiceImpl implements TeamService {
                     String workStatus = "미출근";
                     LocalDate today = LocalDate.now();
 
-                    // 1. 휴가 여부 확인 (VacationRepository 활용)
+                    // 휴가 여부 확인 (VacationRepository 활용)
                     boolean isVacation = vacationRepository.isMemberOnVacation(m.getMemberId(), today, VacationApprove.APPROVED);
 
                     if (isVacation) {
                         workStatus = "휴가";
                     } else {
-                        // 2. 출근 여부 확인 (AttendanceRepository 활용)
+                        // 출근 여부 확인 (AttendanceRepository 활용)
                         var attendanceOpt = attendanceRepository.findByMemberIdAndAttendanceDate(m.getMemberId(), today);
                         if (attendanceOpt.isPresent()) {
                             // 출근 기록이 있으면 해당 상태(근무중, 퇴근, 지각 등)의 설명을 가져옴

--- a/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
@@ -81,4 +81,13 @@ public interface VacationRepository extends JpaRepository<Vacation, Long> {
             @Param("type") VacationType type,
             @Param("status") VacationApprove status
     );
+
+    /** 특정 회원이 특정 날짜에 승인된 휴가 중인지 확인 */
+    @Query("SELECT COUNT(v) > 0 FROM Vacation v " +
+            "WHERE v.member.memberId = :memberId " +
+            "AND v.vacationApprove = :approveStatus " +
+            "AND :today BETWEEN v.vacationStart AND v.vacationEnd")
+    boolean isMemberOnVacation(@Param("memberId") Long memberId,
+                               @Param("today") LocalDate today,
+                               @Param("approveStatus") VacationApprove approveStatus);
 }


### PR DESCRIPTION
## 관련 이슈 번호
- #110 


## 변경 내용
- 팀 상세 정보를 조회할 때 직원의 근태 상태, 휴가 상태도 조회할 수 있도록 변경

## 리뷰 포인트
- 제대로 근태 상태를 받아오는지 확인

## 체크리스트
- [v] 빌드/컴파일 정상
- [v] 로컬 테스트 완료
- [v] 불필요 코드 제거
- [v] 브랜치 전략 준수