### PR TITLE
feat: 기존 memberId 읽어오기를 token으로 변경 #123

### DIFF
--- a/src/main/java/com/mcn/in4/domain/health/controller/HealthCreatorController.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/HealthCreatorController.java
@@ -5,6 +5,7 @@ import com.mcn.in4.domain.health.service.HealthService;
 import com.mcn.in4.domain.health.controller.api.CreatorHealthApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,7 +20,8 @@ public class HealthCreatorController implements CreatorHealthApi {
 
     @GetMapping("/")
     public CreatorHealthInfo generateCreatorHealthInfo(
-            @RequestParam Long memberId) {
+            @AuthenticationPrincipal String userId) {
+        Long memberId = Long.parseLong(userId);
         return healthService.generateCreatorHealthInfo(memberId);
     }
 }

--- a/src/main/java/com/mcn/in4/domain/health/controller/HealthMypageController.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/HealthMypageController.java
@@ -7,6 +7,7 @@ import com.mcn.in4.domain.health.service.HealthService;
 import com.mcn.in4.domain.health.controller.api.MypageHealthApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -23,9 +24,10 @@ public class HealthMypageController implements MypageHealthApi {
 
     @GetMapping("/")
     public List<HealthResponseDto.HealthInfo> generateHealthInfo(
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal String userId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate){
+        Long memberId = Long.parseLong(userId);
         return healthService.generateHealthInfo(memberId, startDate, endDate);
     }
 

--- a/src/main/java/com/mcn/in4/domain/health/controller/api/CreatorHealthApi.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/api/CreatorHealthApi.java
@@ -4,6 +4,7 @@ import com.mcn.in4.domain.health.dto.HealthResponseDto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Health", description = "건강 관리 API")
@@ -13,7 +14,6 @@ public interface CreatorHealthApi {
             description = "memberId를 기준으로 해당 크리에이터의 최신 건강 정보를 생성하여 반환합니다."
     )
     CreatorHealthInfo generateCreatorHealthInfo(
-            @Parameter(description = "크리에이터 회원 ID", example = "1003", required = true)
-            @RequestParam Long memberId
+            @AuthenticationPrincipal String userId
     );
 }

--- a/src/main/java/com/mcn/in4/domain/health/controller/api/MypageHealthApi.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/api/MypageHealthApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,12 +25,7 @@ public interface MypageHealthApi {
     @GetMapping("/")
     List<HealthResponseDto.HealthInfo> generateHealthInfo(
 
-            @Parameter(
-                    description = "회원 ID",
-                    example = "1001",
-                    required = true
-            )
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal String userId,
 
             @Parameter(
                     description = "조회 시작 날짜",


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #123


## 변경 내용
- HealthCreatorController 에서 읽어오던 memberId를 token에서 읽어온 userId로 변경
- HealthMypageController 에서 읽어오던 memberId를 token에서 읽어온 userId로 변경

## 리뷰 포인트
- 

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수