### PR TITLE
Feat/127 uploader profile contract

### DIFF
--- a/src/main/java/com/mcn/in4/domain/health/controller/HealthMypageController.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/HealthMypageController.java
@@ -1,7 +1,7 @@
 package com.mcn.in4.domain.health.controller;
 
-import com.mcn.in4.domain.health.dto.HealthRequestDto;
-import com.mcn.in4.domain.health.dto.HealthResponseDto;
+import com.mcn.in4.domain.health.dto.HealthRequestDto.HealthUpload;
+import com.mcn.in4.domain.health.dto.HealthResponseDto.*;
 import com.mcn.in4.domain.health.entity.CheckupSummanary;
 import com.mcn.in4.domain.health.service.HealthService;
 import com.mcn.in4.domain.health.controller.api.MypageHealthApi;
@@ -23,7 +23,7 @@ public class HealthMypageController implements MypageHealthApi {
     private final HealthService healthService;
 
     @GetMapping("/")
-    public List<HealthResponseDto.HealthInfo> generateHealthInfo(
+    public List<HealthInfo> generateHealthInfo(
             @AuthenticationPrincipal String userId,
             @RequestParam LocalDate startDate,
             @RequestParam LocalDate endDate){
@@ -33,8 +33,9 @@ public class HealthMypageController implements MypageHealthApi {
 
     @PostMapping("/upload")
     @ResponseBody
-    public HealthResponseDto.HealthPresigned generatePresignedUrl(HealthRequestDto.HealthUpload request){
-        Long memberId = request.getMemberId();
+    public HealthPresigned generatePresignedUrl(@AuthenticationPrincipal String userId,
+                                                HealthUpload request){
+        Long memberId = Long.parseLong(userId);
         String checkupName = request.getName();
         LocalDate date = request.getDate();
         CheckupSummanary checkupSummanary = request.getSummanary();

--- a/src/main/java/com/mcn/in4/domain/health/controller/api/MypageHealthApi.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/api/MypageHealthApi.java
@@ -54,6 +54,8 @@ public interface MypageHealthApi {
     @ResponseBody
     HealthResponseDto.HealthPresigned generatePresignedUrl(
 
+            @AuthenticationPrincipal String userId,
+
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "건강 정보 업로드 요청 데이터",
                     required = true

--- a/src/main/java/com/mcn/in4/domain/health/dto/HealthRequestDto.java
+++ b/src/main/java/com/mcn/in4/domain/health/dto/HealthRequestDto.java
@@ -14,21 +14,9 @@ public class HealthRequestDto {
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class HealthUpload{
-        private Long memberId;
         private String name;
         private LocalDate date;
         private CheckupSummanary summanary;
         private MultipartFile file;
-    }
-
-    //Get, 일정목록을 반환받기위한 요청을 받기 위한 Request
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class HealthList{
-        private Long memberId;
-        private LocalDate searchStartDate;
-        private LocalDate searchEndDate;
     }
 }

--- a/src/main/java/com/mcn/in4/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mcn/in4/domain/member/controller/MemberController.java
@@ -2,12 +2,12 @@ package com.mcn.in4.domain.member.controller;
 
 import com.mcn.in4.domain.member.dto.MemberProfileResponseDto;
 import com.mcn.in4.domain.member.service.MemberService;
+import com.mcn.in4.domain.member.dto.MemberProfileRequestDto.ProfileUpload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,4 +23,17 @@ public class MemberController {
         MemberProfileResponseDto profileDto = memberService.getMemberProfile(memberId);
         return ResponseEntity.ok(profileDto);
     }
+
+    @PostMapping("/upload")
+    @ResponseBody
+    public ResponseEntity<MemberProfileResponseDto> generatePresignedUrl(
+            @AuthenticationPrincipal String userId,
+            ProfileUpload request){
+
+        Long memberId = Long.parseLong(userId);
+        MultipartFile file = request.getFile();
+        MemberProfileResponseDto profileContaignPresign = memberService.generatePresignedUrl(memberId, file);
+        return ResponseEntity.ok(profileContaignPresign);
+    }
+
 }

--- a/src/main/java/com/mcn/in4/domain/member/dto/MemberProfileRequestDto.java
+++ b/src/main/java/com/mcn/in4/domain/member/dto/MemberProfileRequestDto.java
@@ -1,0 +1,16 @@
+package com.mcn.in4.domain.member.dto;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+public class MemberProfileRequestDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProfileUpload{
+        private MultipartFile file;
+    }
+
+}

--- a/src/main/java/com/mcn/in4/domain/member/dto/MemberProfileResponseDto.java
+++ b/src/main/java/com/mcn/in4/domain/member/dto/MemberProfileResponseDto.java
@@ -31,4 +31,7 @@ public class MemberProfileResponseDto {
     private String hireDate; // 입사일
     private String address; // 주소
     private Double vacationRemainder; // 잔여 연차
+
+    //프리사인드 URL 소통로
+    private String presignedURL;
 }

--- a/src/main/java/com/mcn/in4/domain/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/mcn/in4/domain/member/repository/MemberProfileRepository.java
@@ -3,6 +3,7 @@ package com.mcn.in4.domain.member.repository;
 import com.mcn.in4.domain.member.entity.Member;
 import com.mcn.in4.domain.member.entity.MemberProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +21,9 @@ public interface MemberProfileRepository extends JpaRepository<MemberProfile, Lo
     List<MemberProfile> findByMemberIds(@Param("memberIds") List<Long> memberIds);
     
     Optional<MemberProfile> findByMember(Member member);
+
+    @Modifying
+    @Query("update MemberProfile mp set mp.profileImage = :profileImage where mp.member.memberId = :memberId ")
+    int updateProfileImage(@Param("memberId") Long memberId,
+                           @Param("profileImage") String profileImage);
 }

--- a/src/main/java/com/mcn/in4/domain/member/service/MemberService.java
+++ b/src/main/java/com/mcn/in4/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.mcn.in4.domain.member.service;
 
 import com.mcn.in4.domain.member.dto.MemberProfileResponseDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
     MemberProfileResponseDto getMemberProfile(Long memberId);
+    MemberProfileResponseDto generatePresignedUrl(Long memberId, MultipartFile file);
 }

--- a/src/main/java/com/mcn/in4/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/member/service/MemberServiceImpl.java
@@ -9,8 +9,17 @@ import com.mcn.in4.domain.member.repository.MemberEmployeeDetailRepository;
 import com.mcn.in4.domain.member.repository.MemberProfileRepository;
 import com.mcn.in4.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +29,16 @@ public class MemberServiceImpl implements MemberService {
         private final MemberRepository memberRepository;
         private final MemberProfileRepository memberProfileRepository;
         private final MemberEmployeeDetailRepository memberEmployeeDetailRepository;
+        private final S3Presigner s3Presigner;
 
-        @Override
+        @Value("${aws.region}")
+        private String region;
+
+        @Value("${aws.s3.bucket}")
+        private String bucket;
+
+
+    @Override
         public MemberProfileResponseDto getMemberProfile(Long memberId) {
                 // 1. 회원 조회
                 Member member = memberRepository.findById(memberId)
@@ -65,4 +82,32 @@ public class MemberServiceImpl implements MemberService {
 
                 return builder.build();
         }
+
+    public MemberProfileResponseDto generatePresignedUrl(Long memberId, MultipartFile file){
+        String fileName = file.getOriginalFilename();
+        String s3key = "public/" + UUID.randomUUID().toString() + "/" + fileName;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3key)
+                .contentType(file.getContentType())
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+                PutObjectPresignRequest.builder()
+                        .putObjectRequest(putObjectRequest)
+                        .signatureDuration(Duration.ofHours(1)) //유효시간 1시간
+                        .build()
+        );
+
+        String presignedUrl = presignedRequest.url().toString();
+
+        String viewUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3key;
+
+        memberProfileRepository.updateProfileImage(memberId, viewUrl);
+
+        return MemberProfileResponseDto.builder()
+                .presignedURL(presignedUrl)
+                .build();
+    }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #127


## 변경 내용
- MemberController에 generatePresignedUrl 추가
- MemberResponseDto에 presignedURL 추가
- MemberProfileRepository에 updateProfileImage 추가
- MemberService에 generatePresignedUrl 추가

## 리뷰 포인트
- 포스트맨 "직원업로드 + 프리사인드URL리턴"에서 Body에 올리고싶은 file 올리고 send시 H2 memberProfile 업데이트 확인
- 상기 코드 send시 return받은 JSON에서 presignedURL 확인하고, 해당 URL 복사해서 업로드 테스트 PUT 링크에 붙여넣기
- Body에 처음에 업로드한 file 넣고, Header의 Content-Type의 Value를 file과 같은 타입으로 변경

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수