### PR TITLE
feat: 직원 및 크리에이터 id 반환 추가

### DIFF
--- a/src/main/java/com/mcn/in4/domain/employee/dto/responseDTO/EmployeeResponseDTO.java
+++ b/src/main/java/com/mcn/in4/domain/employee/dto/responseDTO/EmployeeResponseDTO.java
@@ -14,6 +14,7 @@ public class EmployeeResponseDTO {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class EmployeeDetailResponseDto {
         // Member 엔티티 데이터
+        private Long memberid;
         private String memberAccount;    // 아이디
         private String memberName;       // 이름
         private MemberRole memberRole;   // 권한
@@ -57,6 +58,7 @@ public class EmployeeResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class EmployeeListDto {
+        private Long memberid;
         private String memberName;      // 이름
         private String departmentName;  // 부서
         private String task;            // 직무

--- a/src/main/java/com/mcn/in4/domain/employee/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/employee/service/EmployeeServiceImpl.java
@@ -48,6 +48,7 @@ public class EmployeeServiceImpl implements EmployeeService{
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_DETAIL_NOT_FOUND));
         
         return EmployeeResponseDTO.EmployeeDetailResponseDto.builder()
+                .memberid(member.getMemberId())
                 .memberAccount(member.getMemberAccount())
                 .memberName(member.getMemberName())
                 .memberRole(member.getMemberRole())
@@ -103,6 +104,7 @@ public class EmployeeServiceImpl implements EmployeeService{
             //  status가 있으면 설명을 가져오고 없으면 미출근 문자열 넣기
             String statusText = (status != null) ? status.getDescription() : "미출근";
             return EmployeeResponseDTO.EmployeeListDto.builder()
+                    .memberid(memberId)
                     .memberName(member.getMemberName())
                     .departmentName(member.getDepartment() != null ? member.getDepartment().getDepartmentName() : "소속 없음")
                     .task(member.getTask())


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #


## 변경 내용
- employee DTO  memberId 추가 
- creator memberId 반환 


## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수