### PR TITLE
feat: SecurityConfig, lombok update

### DIFF
--- a/src/main/java/com/mcn/in4/domain/creator/entity/CreatorWork.java
+++ b/src/main/java/com/mcn/in4/domain/creator/entity/CreatorWork.java
@@ -3,10 +3,8 @@ package com.mcn.in4.domain.creator.entity;
 import com.mcn.in4.domain.creator.entity.creatorEnum.WorkStatus;
 import com.mcn.in4.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 
 @Entity
 @Table(name = "creator_work") // 실제 DB 테이블명

--- a/src/main/java/com/mcn/in4/global/config/SecurityConfig.java
+++ b/src/main/java/com/mcn/in4/global/config/SecurityConfig.java
@@ -18,11 +18,13 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
@@ -30,51 +32,52 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                       // Swagger 권한
-                       .requestMatchers(
-                               "/swagger-ui/**",
-                               "/v3/api-docs/**",
-                               "/swagger-ui.html"
-                       ).permitAll()
+                        // Swagger 권한
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html")
+                        .permitAll()
 
-                        //인증없이 가능한 경우
-                        .requestMatchers(HttpMethod.POST,"/api/auth/login").permitAll()
-//                        .requestMatchers(HttpMethod.POST,"/**").permitAll()
+                        // 인증없이 가능한 경우
+                        .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                        // .requestMatchers(HttpMethod.POST,"/**").permitAll()
 
-                          // 관리자 전용
-                          // 크리에이터 관리
-                          .requestMatchers(HttpMethod.GET, "/api/creators").hasRole("ADMINISTRATOR")
-                          .requestMatchers(HttpMethod.POST, "/api/creators").hasRole("ADMINISTRATOR")
-                          // 담당하는 크리에이터 조회
-                          .requestMatchers(HttpMethod.GET, "/api/creators/my").hasAnyRole("MANAGER", "ADMINISTRATOR")
-                          .requestMatchers(HttpMethod.GET, "/api/creators/{creatorId}").hasRole("ADMINISTRATOR")
-                          .requestMatchers(HttpMethod.PATCH, "/api/creators/{creatorId}").hasRole("ADMINISTRATOR")
-                          .requestMatchers(HttpMethod.DELETE, "/api/creators/{creatorId}").hasRole("ADMINISTRATOR")
+                        // 관리자 전용
+                        // 크리에이터 관리
+                        .requestMatchers(HttpMethod.GET, "/api/creators").hasRole("ADMINISTRATOR")
+                        .requestMatchers(HttpMethod.POST, "/api/creators").hasRole("ADMINISTRATOR")
+                        // 담당하는 크리에이터 조회
+                        .requestMatchers(HttpMethod.GET, "/api/creators/my").hasAnyRole("MANAGER", "ADMINISTRATOR")
+                        .requestMatchers(HttpMethod.GET, "/api/creators/{creatorId}")
+                        .hasAnyRole("ADMINISTRATOR", "CREATOR", "MANAGER")
+                        .requestMatchers(HttpMethod.PATCH, "/api/creators/{creatorId}").hasRole("ADMINISTRATOR")
+                        .requestMatchers(HttpMethod.DELETE, "/api/creators/{creatorId}").hasRole("ADMINISTRATOR")
 
-                          // 계약 관리
-                          .requestMatchers(HttpMethod.GET, "/api/contracts").hasRole("ADMINISTRATOR")
-                          .requestMatchers(HttpMethod.POST, "/api/contracts").hasRole("ADMINISTRATOR")
+                        // 계약 관리
+                        .requestMatchers(HttpMethod.GET, "/api/contracts").hasRole("ADMINISTRATOR")
+                        .requestMatchers(HttpMethod.POST, "/api/contracts").hasRole("ADMINISTRATOR")
 
-                          // 법률 세무 관리
-                          .requestMatchers(HttpMethod.GET, "/api/legaltax/admin/all").hasRole("ADMINISTRATOR")
-                          .requestMatchers(HttpMethod.PATCH, "/api/legaltax/{legalTaxId}/complete").hasRole("ADMINISTRATOR")
+                        // 법률 세무 관리
+                        .requestMatchers(HttpMethod.GET, "/api/legaltax/admin/all").hasRole("ADMINISTRATOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/legaltax/{legalTaxId}/complete")
+                        .hasRole("ADMINISTRATOR")
 
-
-                        //나머지경로
-                        .anyRequest().authenticated()
-                )
+                        // 나머지경로
+                        .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
         corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         corsConfiguration.addAllowedHeader("*");
-        corsConfiguration.setAllowCredentials(true); //인증정보를 포함한 cors요청 허용
-        corsConfiguration.setMaxAge(3600L); //1시간
+        corsConfiguration.setAllowCredentials(true); // 인증정보를 포함한 cors요청 허용
+        corsConfiguration.setMaxAge(3600L); // 1시간
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", corsConfiguration);


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #161 


## 변경 내용
- SecurityConfig에서 크리에이터도 크리에이터 상세를 조회할 수 있도록 수정

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수