### PR TITLE
feat: 크리에이터 건강 완료 #138

### DIFF
--- a/src/main/java/com/mcn/in4/domain/health/controller/HealthCreatorController.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/HealthCreatorController.java
@@ -5,11 +5,11 @@ import com.mcn.in4.domain.health.service.HealthService;
 import com.mcn.in4.domain.health.controller.api.CreatorHealthApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Slf4j
 @RestController
@@ -23,5 +23,14 @@ public class HealthCreatorController implements CreatorHealthApi {
             @AuthenticationPrincipal String userId) {
         Long memberId = Long.parseLong(userId);
         return healthService.generateCreatorHealthInfo(memberId);
+    }
+
+    @PostMapping("/upload/mental")
+    public ResponseEntity<Void> saveMentalHealthTest(
+            @AuthenticationPrincipal String userId,
+            @RequestParam Long score){
+        Long memberId = Long.parseLong(userId);
+        healthService.saveMentalHealthTest(memberId, score);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/mcn/in4/domain/health/controller/api/CreatorHealthApi.java
+++ b/src/main/java/com/mcn/in4/domain/health/controller/api/CreatorHealthApi.java
@@ -4,7 +4,9 @@ import com.mcn.in4.domain.health.dto.HealthResponseDto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Health", description = "건강 관리 API")
@@ -15,5 +17,15 @@ public interface CreatorHealthApi {
     )
     CreatorHealthInfo generateCreatorHealthInfo(
             @AuthenticationPrincipal String userId
+    );
+
+    @Operation(
+            summary = "정신 건강 검사 결과 저장",
+            description = "로그인한 사용자의 PHQ-9 정신 건강 검사 점수를 저장하고, 생성된 검사 기록의 ID를 반환합니다."
+    )
+    @PostMapping("/upload/mental")
+    ResponseEntity<Void> saveMentalHealthTest(
+            @AuthenticationPrincipal String userId,
+            @RequestParam Long score
     );
 }

--- a/src/main/java/com/mcn/in4/domain/health/dto/HealthResponseDto.java
+++ b/src/main/java/com/mcn/in4/domain/health/dto/HealthResponseDto.java
@@ -52,6 +52,7 @@ public class HealthResponseDto {
         private List<HealthSummanaryCountDto> healthSummanaryCountList;
         private List<HealthInfo> healthInfoList;
         private List<MentalHealthDto> mentalHealthInfoList;
+        private List<MentalHealthDto> mentalWarningHealthInfoList;
     }
 
     @Getter

--- a/src/main/java/com/mcn/in4/domain/health/dto/MentalHealthDto.java
+++ b/src/main/java/com/mcn/in4/domain/health/dto/MentalHealthDto.java
@@ -11,11 +11,13 @@ import java.time.LocalDate;
 @Builder
 public class MentalHealthDto {
     private Long memberId;
+    private String memberName;
     private LocalDate creatorMentalDate;
     private Long creatorMentalScore;
 
-    public MentalHealthDto(Long memberId, LocalDate creatorMentalDate, Long creatorMentalScore) {
+    public MentalHealthDto(Long memberId, String memberName, LocalDate creatorMentalDate, Long creatorMentalScore) {
         this.memberId = memberId;
+        this.memberName = memberName;
         this.creatorMentalDate = creatorMentalDate;
         this.creatorMentalScore = creatorMentalScore;
     }

--- a/src/main/java/com/mcn/in4/domain/health/entity/CreatorMentalHealth.java
+++ b/src/main/java/com/mcn/in4/domain/health/entity/CreatorMentalHealth.java
@@ -2,10 +2,7 @@ package com.mcn.in4.domain.health.entity;
 
 import com.mcn.in4.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -14,6 +11,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class CreatorMentalHealth {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/mcn/in4/domain/health/repository/CreatorMentalHealthRepository.java
+++ b/src/main/java/com/mcn/in4/domain/health/repository/CreatorMentalHealthRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface CreatorMentalHealthRepository extends JpaRepository<CreatorMentalHealth, Long> {
 
-    @Query("SELECT new com.mcn.in4.domain.health.dto.MentalHealthDto(h.member.memberId, h.creatorMentalDate, h.creatorMentalScore) " +
+    @Query("SELECT new com.mcn.in4.domain.health.dto.MentalHealthDto(h.member.memberId, h.member.memberName,h.creatorMentalDate, h.creatorMentalScore) " +
             "FROM CreatorMentalHealth h " + // 엔티티 클래스명으로 변경
             "WHERE h.member.memberId IN :memberIds " +
             "AND h.creatorMentalDate = (" +
@@ -20,4 +20,15 @@ public interface CreatorMentalHealthRepository extends JpaRepository<CreatorMent
             "    WHERE h2.member.memberId = h.member.memberId" +
             ")")
     List<MentalHealthDto> findLatestMentalHealthByMemberIds(@Param("memberIds") List<Long> memberIds);
+
+    @Query("SELECT new com.mcn.in4.domain.health.dto.MentalHealthDto(h.member.memberId, h.member.memberName,h.creatorMentalDate, h.creatorMentalScore) " +
+            "FROM CreatorMentalHealth h " + // 엔티티 클래스명으로 변경
+            "WHERE h.member.memberId IN :memberIds " +
+            "AND h.creatorMentalDate = (" +
+            "    SELECT MAX(h2.creatorMentalDate) " +
+            "    FROM CreatorMentalHealth h2 " +
+            "    WHERE h2.member.memberId = h.member.memberId" +
+            "    AND h.creatorMentalScore > 9 " +
+            ")")
+    List<MentalHealthDto> findLatestMentalHealthByMemberIdsWhoesDanger(@Param("memberIds") List<Long> memberIds);
 }

--- a/src/main/java/com/mcn/in4/domain/health/service/HealthService.java
+++ b/src/main/java/com/mcn/in4/domain/health/service/HealthService.java
@@ -3,6 +3,7 @@ package com.mcn.in4.domain.health.service;
 import com.mcn.in4.domain.health.dto.HealthResponseDto;
 import com.mcn.in4.domain.health.dto.HealthResponseDto.*;
 import com.mcn.in4.domain.health.entity.CheckupSummanary;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -17,4 +18,5 @@ public interface HealthService {
     List<HealthInfo> findByPeriod(LocalDate startDate, LocalDate endDate);
     List<HealthInfo> findAll();
     List<HealthInfo> generateManageHealthInfo();
+    void saveMentalHealthTest(Long memberId, Long score);
 }

--- a/src/main/java/com/mcn/in4/domain/health/service/HealthServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/health/service/HealthServiceImpl.java
@@ -5,6 +5,7 @@ import com.mcn.in4.domain.health.dto.HealthResponseDto.*;
 import com.mcn.in4.domain.health.dto.HealthSummanaryCountDto;
 import com.mcn.in4.domain.health.dto.MentalHealthDto;
 import com.mcn.in4.domain.health.entity.CheckupSummanary;
+import com.mcn.in4.domain.health.entity.CreatorMentalHealth;
 import com.mcn.in4.domain.health.entity.Health;
 import com.mcn.in4.domain.health.repository.CreatorMentalHealthRepository;
 import com.mcn.in4.domain.health.repository.HealthRepository;
@@ -13,6 +14,7 @@ import com.mcn.in4.domain.member.repository.MemberEmployeeDetailRepository;
 import com.mcn.in4.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,7 +71,8 @@ public class HealthServiceImpl implements HealthService{
                                 .stream()
                                 .map(health -> HealthInfo.from(health, member.getMemberName()))).toList();
         List<MentalHealthDto> creatorHealthInfoC = creatorMentalHealthRepository.findLatestMentalHealthByMemberIds(creatorIds);
-        return new CreatorHealthInfo(creatorHealthInfoA, creatorHealthInfoB, creatorHealthInfoC);
+        List<MentalHealthDto> creatorHealthInfoD = creatorMentalHealthRepository.findLatestMentalHealthByMemberIdsWhoesDanger(creatorIds);
+        return new CreatorHealthInfo(creatorHealthInfoA, creatorHealthInfoB, creatorHealthInfoC, creatorHealthInfoD);
     }
 
     public List<HealthInfo> generateManageHealthInfo() {
@@ -154,5 +157,18 @@ public class HealthServiceImpl implements HealthService{
         return HealthPresigned.builder()
                 .presignedUrl(presignedUrl)
                 .build();
+    }
+
+    public void saveMentalHealthTest(Long memberId, Long score){
+        LocalDate today = LocalDate.now();
+        Member creator = Member.builder()
+                .memberId(memberId)
+                .build();
+        CreatorMentalHealth mentalHealth = CreatorMentalHealth.builder()
+                .creatorMentalDate(today)
+                .creatorMentalScore(score)
+                .member(creator)
+                .build();
+        creatorMentalHealthRepository.save(mentalHealth);
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #138 


## 변경 내용
- 크리에이터 건강 요약 조회 구현
- 크리에이터 건강 최신 조회 구현
- 크리에이터 정신건강 최신 구현

## 리뷰 포인트
- 크리에이터 정신건강 뱃지 없음
- 크리에이터 정신건강 최신 데이터 중복시 데이터 중첩 발생 (추후 수정예정)

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수