### PR TITLE
Feat/165 password api mypage update

### DIFF
--- a/src/main/java/com/mcn/in4/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/mcn/in4/domain/employee/controller/EmployeeController.java
@@ -6,6 +6,7 @@ import com.mcn.in4.domain.employee.dto.responseDTO.EmployeeResponseDTO;
 import com.mcn.in4.domain.employee.service.EmployeeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -51,7 +52,8 @@ public class EmployeeController implements EmployeeApi {
         employeeService.quitEmployee(id, requestDto);
         return ResponseEntity.ok("퇴사 처리가 완료되었습니다.");
     }
-    // 직원 정보 수정
+
+    // 직원 정보 수정 (관리자용)
     @Override
     @PatchMapping("/{id}")
     public ResponseEntity<String> updateEmployee(
@@ -61,5 +63,24 @@ public class EmployeeController implements EmployeeApi {
         return ResponseEntity.ok("직원 정보가 수정되었습니다.");
     }
 
+    // 마이페이지 프로필 수정 (본인용 - JWT 토큰에서 ID 추출)
+    @PatchMapping("/me")
+    public ResponseEntity<EmployeeResponseDTO.EmployeeDetailResponseDto> updateMyProfile(
+            @AuthenticationPrincipal String userId,
+            @RequestBody EmployeeRequestDTO.MyProfileUpdateDto request) {
+        Long memberId = Long.parseLong(userId);
+        EmployeeResponseDTO.EmployeeDetailResponseDto response = employeeService.updateMyProfile(memberId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 비밀번호 변경 (본인용 - JWT 토큰에서 ID 추출)
+    @PatchMapping("/password")
+    public ResponseEntity<String> changePassword(
+            @AuthenticationPrincipal String userId,
+            @RequestBody EmployeeRequestDTO.PasswordChangeDto request) {
+        Long memberId = Long.parseLong(userId);
+        employeeService.changePassword(memberId, request);
+        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+    }
 
 }

--- a/src/main/java/com/mcn/in4/domain/employee/dto/requestDTO/EmployeeRequestDTO.java
+++ b/src/main/java/com/mcn/in4/domain/employee/dto/requestDTO/EmployeeRequestDTO.java
@@ -17,18 +17,18 @@ public class EmployeeRequestDTO {
         private MemberRole memberRole; // 권한
         private MemberStatus memberStatus; // 재직, 휴직
         private String task;// 직무
-        private Integer departmentid; //부서 아이디
+        private Integer departmentid; // 부서 아이디
         private String password; // 비밀번호
 
         // MemberEmployeeDetail 엔티티 속 데이터
-        private String nickname; //닉네임
+        private String nickname; // 닉네임
         private String personalEmail; // 개인 계정
         private String personalCall; // 개인 전화번호
         private String address; // 주소
         private String engName;// 영어이름
-        private String corporEmail; //사내 이메일
+        private String corporEmail; // 사내 이메일
         private String hireDate; // 입사일
-        private EmploymentType employmentType; // 입사유형  NEWBIE, EXPERIENCED
+        private EmploymentType employmentType; // 입사유형 NEWBIE, EXPERIENCED
     }
 
     @Getter
@@ -37,6 +37,7 @@ public class EmployeeRequestDTO {
     public static class EmployeeQuitRequestDto {
         private String leavingReason;
     }
+
     @Getter
     @Builder
     @AllArgsConstructor
@@ -47,16 +48,39 @@ public class EmployeeRequestDTO {
         private MemberRole memberRole; // 권한
         private MemberStatus memberStatus; // 재직, 휴직
         private String task;// 직무
-        private Integer departmentid; //부서 아이디
+        private Integer departmentid; // 부서 아이디
         private String password; // 비밀번호
         // MemberEmployeeDetail 엔티티 속 데이터
-        private String nickname; //닉네임
+        private String nickname; // 닉네임
         private String personalEmail; // 개인 계정
         private String personalCall; // 개인 전화번호
         private String address; // 주소
         private String engName;// 영어이름
-        private String corporEmail; //사내 이메일
+        private String corporEmail; // 사내 이메일
         private String hireDate; // 입사일
-        private EmploymentType employmentType; // 입사유형  NEWBIE, EXPERIENCED
+        private EmploymentType employmentType; // 입사유형 NEWBIE, EXPERIENCED
+    }
+
+    // 마이페이지 프로필 수정 DTO (본인만 수정 가능한 항목)
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MyProfileUpdateDto {
+        private String nickname; // 닉네임
+        private String personalEmail; // 개인 이메일
+        private String personalCall; // 휴대전화
+        private String address; // 주소
+        private String engName; // 영문 이름
+    }
+
+    // 비밀번호 변경 DTO
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PasswordChangeDto {
+        private String currentPassword; // 현재 비밀번호
+        private String newPassword; // 새 비밀번호
     }
 }

--- a/src/main/java/com/mcn/in4/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/mcn/in4/domain/employee/service/EmployeeService.java
@@ -14,8 +14,13 @@ public interface EmployeeService {
     // 직원 퇴사 처리
     void quitEmployee(Long id, EmployeeRequestDTO.EmployeeQuitRequestDto requestDto);
 
-    // 직원 정보 수정
+    // 직원 정보 수정 (관리자용)
     void updateEmployee(Long id, EmployeeRequestDTO.EmployeeUpdateRequestDto requestDto);
 
+    // 마이페이지 프로필 수정 (본인용)
+    EmployeeResponseDTO.EmployeeDetailResponseDto updateMyProfile(Long memberId,
+            EmployeeRequestDTO.MyProfileUpdateDto request);
 
+    // 비밀번호 변경 (본인용)
+    void changePassword(Long memberId, EmployeeRequestDTO.PasswordChangeDto request);
 }

--- a/src/main/java/com/mcn/in4/domain/employee/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/employee/service/EmployeeServiceImpl.java
@@ -18,6 +18,7 @@ import com.mcn.in4.global.error.exception.CustomException;
 import com.mcn.in4.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +36,8 @@ public class EmployeeServiceImpl implements EmployeeService {
         private final MemberEmployeeDetailRepository detailRepository;// 직원 상세
         private final AttendanceRepository attendanceRepository; // 근태
         private final VacationRepository vacationRepository; // 휴가 조회
-
         private final DepartmentRepository departmentRepository; // 부서 레포
+        private final PasswordEncoder passwordEncoder; // 비밀번호 암호화
 
         // 직원 상세 조회
         @Override
@@ -207,48 +208,96 @@ public class EmployeeServiceImpl implements EmployeeService {
                 // 퇴사 사유랑 일자 넣기
                 detailRepository.save(detail);
         }
+
         @Override
         @Transactional
         public void updateEmployee(Long id, EmployeeRequestDTO.EmployeeUpdateRequestDto requestDto) {
 
                 // 엔티티 조회
                 Member member = memberRepository.findById(id)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 직원입니다."));
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 직원입니다."));
 
                 MemberEmployeeDetail detail = detailRepository.findByMemberMemberId(id)
-                        .orElseThrow(() -> new IllegalArgumentException("직원 상세 정보가 없습니다."));
-                //  부서 정보 조회 (부서 변경이 필요할 수 있으므로)
+                                .orElseThrow(() -> new IllegalArgumentException("직원 상세 정보가 없습니다."));
+                // 부서 정보 조회 (부서 변경이 필요할 수 있으므로)
                 Department department = null;
                 if (requestDto.getDepartmentid() != null) {
                         department = departmentRepository.findById(requestDto.getDepartmentid().longValue())
-                                .orElseThrow(() -> new IllegalArgumentException(
-                                        "존재하지 않는 부서입니다. ID: " + requestDto.getDepartmentid()));
+                                        .orElseThrow(() -> new IllegalArgumentException(
+                                                        "존재하지 않는 부서입니다. ID: " + requestDto.getDepartmentid()));
                 }
-                //  Member 엔티티 수정
+                // Member 엔티티 수정
                 member.updateInfo(
-                        requestDto.getMemberName(),
-                        requestDto.getMemberRole(),
-                        requestDto.getMemberStatus(),
-                        requestDto.getTask(),
-                        department
-                );
+                                requestDto.getMemberName(),
+                                requestDto.getMemberRole(),
+                                requestDto.getMemberStatus(),
+                                requestDto.getTask(),
+                                department);
                 // 비밀번호 수정 (입력값이 있을 때만)
                 if (requestDto.getPassword() != null && !requestDto.getPassword().isEmpty()) {
 
                         member.updatePassword(requestDto.getPassword());
                 }
-                //  MemberEmployeeDetail 엔티티 수정
+                // MemberEmployeeDetail 엔티티 수정
                 detail.updateDetail(
-                        requestDto.getNickname(),
-                        requestDto.getPersonalEmail(),
-                        requestDto.getPersonalCall(),
-                        requestDto.getAddress(),
-                        requestDto.getEngName(),
-                        requestDto.getCorporEmail(),
-                        requestDto.getHireDate(),
-                        requestDto.getEmploymentType()
+                                requestDto.getNickname(),
+                                requestDto.getPersonalEmail(),
+                                requestDto.getPersonalCall(),
+                                requestDto.getAddress(),
+                                requestDto.getEngName(),
+                                requestDto.getCorporEmail(),
+                                requestDto.getHireDate(),
+                                requestDto.getEmploymentType());
+
+        }
+
+        // 마이페이지 프로필 수정 (본인용)
+        @Override
+        @Transactional
+        public EmployeeResponseDTO.EmployeeDetailResponseDto updateMyProfile(Long memberId,
+                        EmployeeRequestDTO.MyProfileUpdateDto request) {
+                // 1. 회원 조회
+                Member member = memberRepository.findById(memberId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+                // 2. 직원 상세 정보 조회
+                MemberEmployeeDetail detail = detailRepository.findByMember(member)
+                                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_DETAIL_NOT_FOUND));
+
+                // 3. 정보 업데이트
+                // 3. 정보 업데이트
+                detail.updateDetail(
+                                request.getNickname() != null ? request.getNickname() : detail.getNickname(),
+                                request.getPersonalEmail() != null ? request.getPersonalEmail()
+                                                : detail.getPersonalEmail(),
+                                request.getPersonalCall() != null ? request.getPersonalCall()
+                                                : detail.getPersonalCall(),
+                                request.getAddress() != null ? request.getAddress() : detail.getAddress(),
+                                request.getEngName() != null ? request.getEngName() : detail.getEngName(),
+                                detail.getCorporEmail(), // 기존 값 유지
+                                detail.getHireDate(), // 기존 값 유지
+                                detail.getEmploymentType() // 기존 값 유지
                 );
 
+                // 4. 업데이트된 정보 반환
+                return getEmployeeDetail(memberId);
+        }
 
+        // 비밀번호 변경 (본인용)
+        @Override
+        @Transactional
+        public void changePassword(Long memberId, EmployeeRequestDTO.PasswordChangeDto request) {
+                // 1. 회원 조회
+                Member member = memberRepository.findById(memberId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+                // 2. 현재 비밀번호 검증 (평문 비교 - 기존 로그인 로직과 동일하게)
+                if (!request.getCurrentPassword().equals(member.getMemberPassword())) {
+                        throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+                }
+
+                // 3. 새 비밀번호 업데이트 (평문 저장)
+                member.updatePassword(request.getNewPassword());
+                memberRepository.save(member);
         }
 }

--- a/src/main/java/com/mcn/in4/global/config/SecurityConfig.java
+++ b/src/main/java/com/mcn/in4/global/config/SecurityConfig.java
@@ -63,6 +63,12 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/api/legaltax/{legalTaxId}/complete")
                         .hasRole("ADMINISTRATOR")
 
+                        // 직원 마이페이지 (CREATOR 제외)
+                        .requestMatchers(HttpMethod.PATCH, "/api/employees/me")
+                        .hasAnyRole("EMPLOYEE", "MANAGER", "ADMINISTRATOR")
+                        .requestMatchers(HttpMethod.PATCH, "/api/employees/password")
+                        .hasAnyRole("EMPLOYEE", "MANAGER", "ADMINISTRATOR")
+
                         // 나머지경로
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #165 


## 변경 내용
- 마이페이지 정보 수정 및 비밀번호 api 기능 구현

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수