### PR TITLE
fix: 부서 삭제되도 직원 부서 null 되도록 변경 #172

### DIFF
--- a/src/main/java/com/mcn/in4/domain/department/service/DepartmentServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/department/service/DepartmentServiceImpl.java
@@ -68,8 +68,18 @@ public class DepartmentServiceImpl implements DepartmentService {
 
     @Override
     public void deleteDepartment(Long id) {
+        //삭제할 부서 조회
         Department department = departmentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 부서가 존재하지 않습니다. id=" + id));
+
+        //해당 부서에 소속된 직원들을 조회
+        List<Member> members = memberRepository.findByDepartment_DepartmentId(id);
+
+        //직원들의 부서 정보를 null로 변경 (연관관계 끊기)
+        for (Member member : members) {
+            member.changeDepartment(null); // 방금 추가한 메서드 사용
+        }
+        //부서 삭제
         departmentRepository.delete(department);
     }
 

--- a/src/main/java/com/mcn/in4/domain/member/entity/Member.java
+++ b/src/main/java/com/mcn/in4/domain/member/entity/Member.java
@@ -70,4 +70,7 @@ public class Member {
         this.memberPassword = password;
     }
 
+    public void changeDepartment(Department department) {
+        this.department = department;
+    }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- #172 


## 변경 내용
부서 삭제되도 직원 부서 null 되도록 변경

## 리뷰 포인트
제대로 삭제되는지 확인

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수