### PR TITLE
feat: 크리에이터 개인 건강관리 작성 #183

### DIFF
--- a/src/main/java/com/mcn/in4/domain/health/service/HealthServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/health/service/HealthServiceImpl.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -69,7 +70,9 @@ public class HealthServiceImpl implements HealthService{
         MemberRole role = memberRepository.findMemberRoleByMemberId(memberId);
         if (role==MemberRole.ADMINISTRATOR){
             creatorHealthInfo = generateCreatorForAdmin();
-        } else{
+        } else if(role==MemberRole.CREATOR) {
+            creatorHealthInfo = generateCreatorForCreator(memberId);
+        }else{
             creatorHealthInfo = generateCreatorForManager(memberId);
         }
 
@@ -99,6 +102,19 @@ public class HealthServiceImpl implements HealthService{
                         .map(health -> HealthInfo.from(health, member.getMemberName()))).toList();
         List<MentalHealthDto> creatorHealthInfoC = creatorMentalHealthRepository.findLatestMentalHealthByMemberIds(creatorIds);
         List<MentalHealthDto> creatorHealthInfoD = creatorMentalHealthRepository.findLatestMentalHealthByMemberIdsWhoesDanger(creatorIds);
+        return new CreatorHealthInfo(creatorHealthInfoA, creatorHealthInfoB, creatorHealthInfoC, creatorHealthInfoD);
+    }
+
+    public CreatorHealthInfo generateCreatorForCreator(Long memberId){
+        List<Long> creatorId = Collections.singletonList(memberId);
+        List<Member> creators = memberRepository.findByMemberIdIn(creatorId);
+        List<HealthSummanaryCountDto> creatorHealthInfoA = healthRepository.countGroupedByCheckupSummanaryForMembers();
+        List<HealthInfo> creatorHealthInfoB = creators.stream().flatMap(member ->
+                healthRepository.findTopByMember_MemberId(member.getMemberId())
+                        .stream()
+                        .map(health -> HealthInfo.from(health, member.getMemberName()))).toList();
+        List<MentalHealthDto> creatorHealthInfoC = creatorMentalHealthRepository.findLatestMentalHealthByMemberIds(creatorId);
+        List<MentalHealthDto> creatorHealthInfoD = creatorMentalHealthRepository.findLatestMentalHealthByMemberIdsWhoesDanger(creatorId);
         return new CreatorHealthInfo(creatorHealthInfoA, creatorHealthInfoB, creatorHealthInfoC, creatorHealthInfoD);
     }
 


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #183


## 변경 내용
- 크리에이터 계정으로 로그인 시, 크리에이터 개인의 건강관리정보 조회되도록 변경

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수