### PR TITLE
feat: password update exception

### DIFF
--- a/src/main/java/com/mcn/in4/domain/employee/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/employee/service/EmployeeServiceImpl.java
@@ -296,6 +296,11 @@ public class EmployeeServiceImpl implements EmployeeService {
                         throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
                 }
 
+                // 새로운 비밀번호가 기존 비밀번호와 같은지, 같다면 에러
+                if (request.getNewPassword().equals(member.getMemberPassword())) {
+                        throw new CustomException(ErrorCode.SAME_PASSWORD);
+                }
+
                 // 3. 새 비밀번호 업데이트 (평문 저장)
                 member.updatePassword(request.getNewPassword());
                 memberRepository.save(member);

--- a/src/main/java/com/mcn/in4/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/mcn/in4/global/error/exception/ErrorCode.java
@@ -3,6 +3,7 @@ package com.mcn.in4.global.error.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
@@ -18,6 +19,7 @@ public enum ErrorCode {
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "로그인 정보가 일치하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "새 비밀번호는 기존 비밀번호와 다르게 설정해야 합니다."),
     // 3. 회원/직원 (Member / Employee)
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #


## 변경 내용
- 비밀번로 수정시 글로벌 예외처리 

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수