### PR TITLE
feat: 크리에이터 일정 수정 기능 추가

### DIFF
--- a/src/main/java/com/mcn/in4/domain/schedule/controller/api/ScheduleApi.java
+++ b/src/main/java/com/mcn/in4/domain/schedule/controller/api/ScheduleApi.java
@@ -13,6 +13,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import java.util.List;
 
@@ -42,4 +45,29 @@ public interface ScheduleApi {
         ResponseEntity<List<SchedulReponseDTO.ScheduleResponseDto>> getMyMonthlySchedules(
                         @Parameter(hidden = true) String userId,
                         @Parameter(description = "조회 년월 (YYYY-MM)", example = "2026-02") @RequestParam("month") String month);
+
+        @Operation(summary = "일정 수정", description = "기존 일정을 수정합니다. 일정 타입이 변경될 경우, 방문자(Visitor) 정보가 그에 맞게 초기화되거나 갱신될 수 있습니다.", responses = {
+                        @ApiResponse(responseCode = "200", description = "수정 성공"),
+                        @ApiResponse(responseCode = "403", description = "수정 권한 없음 (본인 일정 또는 관리자의 회사 일정만 수정 가능)")
+        })
+        @PatchMapping("/{scheduleId}")
+        ResponseEntity<String> updateSchedule(
+                        @Parameter(hidden = true) String userId,
+                        @Parameter(hidden = true) Authentication authentication,
+                        @Parameter(description = "일정 ID", required = true) @PathVariable("scheduleId") Long scheduleId,
+                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정할 일정 정보 (타입 변경 시 visitorIds 처리 주의)", required = true, content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "1. 콘텐츠 -> 합방(MERGE)으로 변경", summary = "일반 일정을 합방으로 변경하며 방문자 추가", value = "{\n  \"scheduleName\": \"급하게 잡힌 합방\",\n  \"scheduleDate\": \"2026-02-15\",\n  \"scheduleDetail\": \"갑자기 합방하기로 함\",\n  \"scheduleType\": \"MERGE\",\n  \"creatorId\": 2001,\n  \"visitorIds\": [2002, 2005]\n}"),
+                                        @ExampleObject(name = "2. 합방 -> 기타(PERSONAL)로 변경", summary = "합방이 취소되어 개인 일정으로 변경 (방문자 자동 삭제됨)", value = "{\n  \"scheduleName\": \"합방 취소 - 개인 휴식\",\n  \"scheduleDate\": \"2026-02-15\",\n  \"scheduleDetail\": \"합방 취소됨\",\n  \"scheduleType\": \"ETC\",\n  \"creatorId\": null,\n  \"visitorIds\": []\n}"),
+                                        @ExampleObject(name = "3. 개인일정 단순 수정", summary = "타입 변경 없이 제목/내용만 수정", value = "{\n  \"scheduleName\": \"수정된 제목\",\n  \"scheduleDate\": \"2026-02-15\",\n  \"scheduleDetail\": \"내용 보완\",\n  \"scheduleType\": \"PERSONAL\",\n  \"creatorId\": null,\n  \"visitorIds\": []\n}")
+                        })) @RequestBody ScheduleRequestDTO.ScheduleUpdateRequestDto requestDto);
+
+        @Operation(summary = "일정 삭제", description = "일정을 삭제합니다. 본인 일정 또는 관리자의 회사 일정만 삭제 가능합니다.", responses = {
+                        @ApiResponse(responseCode = "200", description = "삭제 성공"),
+                        @ApiResponse(responseCode = "403", description = "삭제 권한 없음")
+        })
+        @DeleteMapping("/{scheduleId}")
+        ResponseEntity<String> deleteSchedule(
+                        @Parameter(hidden = true) String userId,
+                        @Parameter(hidden = true) Authentication authentication,
+                        @Parameter(description = "일정 ID", required = true) @PathVariable("scheduleId") Long scheduleId);
 }

--- a/src/main/java/com/mcn/in4/domain/schedule/entity/ScheduleVisitor.java
+++ b/src/main/java/com/mcn/in4/domain/schedule/entity/ScheduleVisitor.java
@@ -1,5 +1,6 @@
 package com.mcn.in4.domain.schedule.entity;
 
+import com.mcn.in4.domain.creator.dto.request.CreatorRequestDTO;
 import com.mcn.in4.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -25,4 +26,6 @@ public class ScheduleVisitor {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
     //참가자 키
+
+
 }

--- a/src/main/java/com/mcn/in4/domain/schedule/repository/SchedulRepository.java
+++ b/src/main/java/com/mcn/in4/domain/schedule/repository/SchedulRepository.java
@@ -40,4 +40,5 @@ public interface SchedulRepository extends JpaRepository<Schedule, Long> {
             @Param("endDate") LocalDate endDate,
             @Param("types") List<ScheduleType> types);
 
+    Schedule findByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/mcn/in4/domain/schedule/repository/ScheduleVisitorRepository.java
+++ b/src/main/java/com/mcn/in4/domain/schedule/repository/ScheduleVisitorRepository.java
@@ -1,5 +1,6 @@
 package com.mcn.in4.domain.schedule.repository;
 
+import com.mcn.in4.domain.schedule.entity.Schedule;
 import com.mcn.in4.domain.schedule.entity.ScheduleVisitor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface ScheduleVisitorRepository extends JpaRepository<ScheduleVisitor, Long> {
     @Query("SELECT sv FROM ScheduleVisitor sv JOIN FETCH sv.member WHERE sv.schedule.scheduleId IN :scheduleIds")
     List<ScheduleVisitor> findAllByScheduleIdIn(@Param("scheduleIds") List<Long> scheduleIds);
+
+    void deleteAllBySchedule(Schedule schedule);
 }

--- a/src/main/java/com/mcn/in4/domain/schedule/service/SchedulServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/schedule/service/SchedulServiceImpl.java
@@ -26,194 +26,216 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class SchedulServiceImpl implements SchedulService {
-    private final SchedulRepository schedulRepository;
-    private final MemberRepository memberRepository;
-    private final CreatorDetailRepository creatorDetailRepository;
-    private final ScheduleVisitorRepository scheduleVisitorRepository;
+        private final SchedulRepository schedulRepository;
+        private final MemberRepository memberRepository;
+        private final CreatorDetailRepository creatorDetailRepository;
+        private final ScheduleVisitorRepository scheduleVisitorRepository;
 
+        @Override
+        @Transactional
+        public void createSchedule(Long memberId, String role, ScheduleRequestDTO.ScheduleCreateRequestDto requestDto) {
 
-    @Override
-    @Transactional
-    public void createSchedule(Long memberId, String role, ScheduleRequestDTO.ScheduleCreateRequestDto requestDto) {
+                // 어드민 외 회사일정 등록 불가
+                if (!"ROLE_ADMINISTRATOR".equals(role) &&
+                                requestDto.getScheduleType() == ScheduleType.COMPANY) {
+                        throw new IllegalStateException("일반 직원 및 크리에이터는 회사 일정을 등록할 수 있는 권한이 없습니다.");
+                }
 
-        // 직원과 크리에이터 회사일정 등록 불가
-        if (("ROLE_EMPLOYEE".equals(role) || "ROLE_CREATOR".equals(role)) &&
-                requestDto.getScheduleType() == ScheduleType.COMPANY) {
-            throw new IllegalStateException("일반 직원 및 크리에이터는 회사 일정을 등록할 수 있는 권한이 없습니다.");
+                Member member = memberRepository.findById(memberId)
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                log.info("회원 이 유효한지 조회");
+                Member targetCreator = null;
+                if (requestDto.getCreatorId() != null) {
+                        targetCreator = memberRepository.findById(requestDto.getCreatorId())
+                                        .orElseThrow(() -> new CustomException(ErrorCode.CREATOR_NOT_FOUND));
+                }
+                log.info("크리에이터가 유효한지 조회");
+
+                // 일반 일정 등록
+                Schedule schedule = Schedule.builder()
+                                .member(member)
+                                .creator(targetCreator)
+                                .scheduleName(requestDto.getScheduleName())
+                                .scheduleDate(requestDto.getScheduleDate())
+                                .scheduleDetail(requestDto.getScheduleDetail())
+                                .scheduleType(requestDto.getScheduleType())
+                                .build();
+                Schedule savedSchedule = schedulRepository.save(schedule);
+
+                // 합방 타입일 경우에 합방 크리에이터 등록
+                if (requestDto.getScheduleType() == ScheduleType.MERGE &&
+                                requestDto.getVisitorIds() != null && !requestDto.getVisitorIds().isEmpty()) {
+
+                        List<ScheduleVisitor> visitors = requestDto.getVisitorIds().stream()
+                                        .map(visitorId -> memberRepository.findById(visitorId)
+                                                        .orElseThrow(() -> new IllegalArgumentException(
+                                                                        "참가자 정보를 찾을 수 없습니다. ID: " + visitorId)))
+                                        .map(visitorMember -> ScheduleVisitor.builder()
+                                                        .schedule(savedSchedule)
+                                                        .member(visitorMember)
+                                                        .build())
+                                        .toList();
+
+                        scheduleVisitorRepository.saveAll(visitors);
+                }
         }
 
+        @Override
+        @Transactional(readOnly = true)
+        public List<SchedulReponseDTO.ScheduleResponseDto> getMyMonthlySchedules(Long memberId, String month) {
+                // month: "YYYY-MM" 년-월
+                String[] parts = month.split("-");
+                int year = Integer.parseInt(parts[0]);
+                int monthValue = Integer.parseInt(parts[1]);
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-        log.info("회원 이 유효한지 조회");
-        Member targetCreator = null;
-        if (requestDto.getCreatorId() != null) {
-            targetCreator = memberRepository.findById(requestDto.getCreatorId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.CREATOR_NOT_FOUND));
-        }
-        log.info("크리에이터가 유효한지 조회");
+                // 한달
+                LocalDate startDate = LocalDate.of(year, monthValue, 1);
+                LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
+                List<Schedule> schedules = schedulRepository.findMyMonthlySchedules(
+                                memberId,
+                                startDate,
+                                endDate,
+                                ScheduleType.COMPANY,
+                                ScheduleType.PERSONAL);
 
-        //일반 일정 등록
-        Schedule schedule = Schedule.builder()
-                .member(member)
-                .creator(targetCreator)
-                .scheduleName(requestDto.getScheduleName())
-                .scheduleDate(requestDto.getScheduleDate())
-                .scheduleDetail(requestDto.getScheduleDetail())
-                .scheduleType(requestDto.getScheduleType())
-                .build();
-        Schedule savedSchedule = schedulRepository.save(schedule);
+                return schedules.stream()
+                                .map(s -> SchedulReponseDTO.ScheduleResponseDto.builder()
+                                                .scheduleId(s.getScheduleId())
+                                                .scheduleName(s.getScheduleName())
+                                                .scheduleDate(s.getScheduleDate())
+                                                .scheduleDetail(s.getScheduleDetail())
+                                                .scheduleType(s.getScheduleType())
+                                                .build())
+                                .toList();
 
-        //합방 타입일 경우에 합방 크리에이터 등록
-        if (requestDto.getScheduleType() == ScheduleType.MERGE &&
-                requestDto.getVisitorIds() != null && !requestDto.getVisitorIds().isEmpty()) {
-
-            List<ScheduleVisitor> visitors = requestDto.getVisitorIds().stream()
-                    .map(visitorId -> memberRepository.findById(visitorId)
-                            .orElseThrow(() -> new IllegalArgumentException("참가자 정보를 찾을 수 없습니다. ID: " + visitorId)))
-                    .map(visitorMember -> ScheduleVisitor.builder()
-                            .schedule(savedSchedule)
-                            .member(visitorMember)
-                            .build())
-                    .toList();
-
-            scheduleVisitorRepository.saveAll(visitors);
-        }
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<SchedulReponseDTO.ScheduleResponseDto> getMyMonthlySchedules(Long memberId, String month) {
-        // month: "YYYY-MM" 년-월
-        String[] parts = month.split("-");
-        int year = Integer.parseInt(parts[0]);
-        int monthValue = Integer.parseInt(parts[1]);
-
-        // 한달
-        LocalDate startDate = LocalDate.of(year, monthValue, 1);
-        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
-
-
-
-        List<Schedule> schedules = schedulRepository.findMyMonthlySchedules(
-                memberId,
-                startDate,
-                endDate,
-                ScheduleType.COMPANY,
-                ScheduleType.PERSONAL
-        );
-
-        return schedules.stream()
-                .map(s -> SchedulReponseDTO.ScheduleResponseDto.builder()
-                        .scheduleId(s.getScheduleId())
-                        .scheduleName(s.getScheduleName())
-                        .scheduleDate(s.getScheduleDate())
-                        .scheduleDetail(s.getScheduleDetail())
-                        .scheduleType(s.getScheduleType())
-                        .build())
-                .toList();
-
-    }
-
-
-    //어드민 권한 체크 후 일정 삭제
-    @Override
-    public void deleteSchedule(Long memberId, String role, Long scheduleId) {
-
-        Schedule schedule = schedulRepository.findById(scheduleId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 일정입니다."));
-
-        boolean isAdmin = "ROLE_ADMINSTRATOR".equals(role) && schedule.getScheduleType() == ScheduleType.COMPANY;
-
-        boolean isOwner = schedule.getMember().getMemberId().equals(memberId);
-
-        if (!isAdmin && !isOwner) {
-            throw new IllegalStateException("삭제 권한이 없습니다. (본인의 일정 또는 관리자의 회사 일정 삭제만 가능)");
         }
 
-        schedulRepository.delete(schedule);
-        log.info("알림 삭제 완료");
+        // 어드민 권한 체크 후 일정 삭제
+        @Override
+        public void deleteSchedule(Long memberId, String role, Long scheduleId) {
 
+                Schedule schedule = schedulRepository.findById(scheduleId)
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 일정입니다."));
 
-    }
+                boolean isAdmin = "ROLE_ADMINSTRATOR".equals(role)
+                                && schedule.getScheduleType() == ScheduleType.COMPANY;
 
+                boolean isOwner = schedule.getMember().getMemberId().equals(memberId);
 
-    //일정 수정 로직, 권한 체크, 작성자 체크
-    @Override
-    public void updateSchedule(Long memberId, String role, Long scheduleId, ScheduleRequestDTO.ScheduleUpdateRequestDto requestDto) {
-        Schedule schedule = schedulRepository.findById(scheduleId)
-                .orElseThrow(() -> new IllegalArgumentException("일정이 없습니다."));
-        boolean isAdminManager = "ROLE_ADMINISTRATOR".equals(role) && schedule.getScheduleType() == ScheduleType.COMPANY;
-        boolean isOwner = schedule.getMember().getMemberId().equals(memberId);
-        if (!isAdminManager && !isOwner) {
-            throw new IllegalStateException("수정 권한이 없습니다.");
-        }
-        //엔티티안의 메서드로 수정
-        schedule.update(
-                requestDto.getScheduleName(),
-                requestDto.getScheduleDate(),
-                requestDto.getScheduleDetail(),
-                requestDto.getScheduleType()
-        );
+                if (!isAdmin && !isOwner) {
+                        throw new IllegalStateException("삭제 권한이 없습니다. (본인의 일정 또는 관리자의 회사 일정 삭제만 가능)");
+                }
 
-        schedulRepository.save(schedule);
-        log.info("알림 수정 완료");
-    }
+                schedulRepository.delete(schedule);
+                log.info("알림 삭제 완료");
 
-    //크리에이터 일정 조회
-    @Override
-    public List<SchedulReponseDTO.ScheduleResponseDto> getCreatorSchedules(Long memberId, String role, String month) {
-        String[] parts = month.split("-");
-        LocalDate startDate = LocalDate.of(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), 1);
-        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
-
-        List<ScheduleType> creatorTypes = List.of(ScheduleType.CONTENT,
-                ScheduleType.LIVE,
-                ScheduleType.MEETING,
-                ScheduleType.MERGE,
-                ScheduleType.PROMOTION,
-                ScheduleType.ETC);
-
-        //매니저인 경우 크리에이터 목록 조회
-        List<Long> managedCreatorIds = List.of();
-        if ("ROLE_MANAGER".equals(role)) {
-            managedCreatorIds = creatorDetailRepository.findCreatorIdsByManagerId(memberId);
         }
 
-        List<Schedule> schedules = schedulRepository.findCreatorRelatedSchedules(
-                memberId,
-                managedCreatorIds.isEmpty() ? List.of(-1L) : managedCreatorIds, // 빈리스트 일때 -1L 을 임의로 넣어 오류 방지
-                startDate, endDate, creatorTypes
-        );
+        // 일정 수정 로직, 권한 체크, 작성자 체크
+        @Override
+        @Transactional
+        public void updateSchedule(Long memberId, String role, Long scheduleId,
+                        ScheduleRequestDTO.ScheduleUpdateRequestDto requestDto) {
+                Schedule schedule = schedulRepository.findById(scheduleId)
+                                .orElseThrow(() -> new IllegalArgumentException("일정이 없습니다."));
+                boolean isAdminManager = "ROLE_ADMINISTRATOR".equals(role)
+                                && schedule.getScheduleType() == ScheduleType.COMPANY;
+                boolean isOwner = schedule.getMember().getMemberId().equals(memberId);
 
-        // 합방 참가자 조회
-        List<Long> scheduleIds = schedules.stream().map(Schedule::getScheduleId).toList();
-        List<ScheduleVisitor> allVisitors = scheduleVisitorRepository.findAllByScheduleIdIn(scheduleIds);
+                if (!isAdminManager && !isOwner) {
+                        throw new IllegalStateException("수정 권한이 없습니다.");
+                }
 
-        //<스케줄 id, 합방 참가자리스트> <- 맵
-        Map<Long, List<ScheduleVisitor>> visitorMap = allVisitors.stream()
-                .collect(Collectors.groupingBy(sv -> sv.getSchedule().getScheduleId()));
+                // 기존, 업데이트 타입
+                ScheduleType oldType = schedule.getScheduleType();
+                ScheduleType newType = requestDto.getScheduleType();
 
-        return schedules.stream().map(s -> {
-            List<ScheduleVisitor> visitors = visitorMap.getOrDefault(s.getScheduleId(), List.of());
+                schedule.update(
+                                requestDto.getScheduleName(),
+                                requestDto.getScheduleDate(),
+                                requestDto.getScheduleDetail(),
+                                requestDto.getScheduleType());
+                // 합방 관리 로직
+                // 기존 합방 -> 다른 타입 변경시
+                if (oldType == ScheduleType.MERGE && newType != ScheduleType.MERGE) {
+                        scheduleVisitorRepository.deleteAllBySchedule(schedule);
+                        // 합방 테이블에 데이터 삭제
+                } else if (newType == ScheduleType.MERGE) {
+                        // 합방 타입으로 수정하는 경우
+                        scheduleVisitorRepository.deleteAllBySchedule(schedule);
+                        if (requestDto.getVisitorIds() != null && !requestDto.getVisitorIds().isEmpty()) {
+                                List<ScheduleVisitor> newVisitors = requestDto.getVisitorIds().stream()
+                                                .map(visitorId -> memberRepository.findById(visitorId)
+                                                                .orElseThrow(() -> new CustomException(
+                                                                                ErrorCode.CREATOR_NOT_FOUND)))
+                                                .map(member -> ScheduleVisitor.builder()
+                                                                .schedule(schedule)
+                                                                .member(member)
+                                                                .build())
+                                                .toList();
+                                scheduleVisitorRepository.saveAll(newVisitors);
+                        }
+                }
 
-            return SchedulReponseDTO.ScheduleResponseDto.builder()
-                    .scheduleId(s.getScheduleId())
-                    .memberId(s.getMember().getMemberId())
-                    .memberName(s.getMember().getMemberName())
-                    .scheduleName(s.getScheduleName())
-                    .scheduleDate(s.getScheduleDate())
-                    .scheduleDetail(s.getScheduleDetail())
-                    .scheduleType(s.getScheduleType())
-                    // 크리에이터
-                    .creatorId(s.getCreator() != null ? s.getCreator().getMemberId() : null)
-                    .creatorName(s.getCreator() != null ? s.getCreator().getMemberName() : null)
-                    // 합방 상대
-                    .visitorIds(visitors.stream().map(v -> v.getMember().getMemberId()).toList())
-                    .visitorNames(visitors.stream().map(v -> v.getMember().getMemberName()).toList())
-                    .build();
-        }).toList();
+                log.info("일정 수정 완료");
+        }
 
-    }
+        // 크리에이터 일정 조회
+        @Override
+        public List<SchedulReponseDTO.ScheduleResponseDto> getCreatorSchedules(Long memberId, String role,
+                        String month) {
+                String[] parts = month.split("-");
+                LocalDate startDate = LocalDate.of(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), 1);
+                LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+                List<ScheduleType> creatorTypes = List.of(ScheduleType.CONTENT,
+                                ScheduleType.LIVE,
+                                ScheduleType.MEETING,
+                                ScheduleType.MERGE,
+                                ScheduleType.PROMOTION,
+                                ScheduleType.ETC);
+
+                // 매니저인 경우 크리에이터 목록 조회
+                List<Long> managedCreatorIds = List.of();
+                if ("ROLE_MANAGER".equals(role)) {
+                        managedCreatorIds = creatorDetailRepository.findCreatorIdsByManagerId(memberId);
+                }
+
+                List<Schedule> schedules = schedulRepository.findCreatorRelatedSchedules(
+                                memberId,
+                                managedCreatorIds.isEmpty() ? List.of(-1L) : managedCreatorIds, // 빈리스트 일때 -1L 을 임의로 넣어
+                                                                                                // 오류 방지
+                                startDate, endDate, creatorTypes);
+
+                // 합방 참가자 조회
+                List<Long> scheduleIds = schedules.stream().map(Schedule::getScheduleId).toList();
+                List<ScheduleVisitor> allVisitors = scheduleVisitorRepository.findAllByScheduleIdIn(scheduleIds);
+
+                // <스케줄 id, 합방 참가자리스트> <- 맵
+                Map<Long, List<ScheduleVisitor>> visitorMap = allVisitors.stream()
+                                .collect(Collectors.groupingBy(sv -> sv.getSchedule().getScheduleId()));
+
+                return schedules.stream().map(s -> {
+                        List<ScheduleVisitor> visitors = visitorMap.getOrDefault(s.getScheduleId(), List.of());
+
+                        return SchedulReponseDTO.ScheduleResponseDto.builder()
+                                        .scheduleId(s.getScheduleId())
+                                        .memberId(s.getMember().getMemberId())
+                                        .memberName(s.getMember().getMemberName())
+                                        .scheduleName(s.getScheduleName())
+                                        .scheduleDate(s.getScheduleDate())
+                                        .scheduleDetail(s.getScheduleDetail())
+                                        .scheduleType(s.getScheduleType())
+                                        // 크리에이터
+                                        .creatorId(s.getCreator() != null ? s.getCreator().getMemberId() : null)
+                                        .creatorName(s.getCreator() != null ? s.getCreator().getMemberName() : null)
+                                        // 합방 상대
+                                        .visitorIds(visitors.stream().map(v -> v.getMember().getMemberId()).toList())
+                                        .visitorNames(visitors.stream().map(v -> v.getMember().getMemberName())
+                                                        .toList())
+                                        .build();
+                }).toList();
+
+        }
 }

--- a/src/main/java/com/mcn/in4/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/mcn/in4/global/error/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     INVALID_CONTRACT_PERIOD(HttpStatus.BAD_REQUEST, "계약 시작일은 종료일보다 이전이어야 합니다."),
     CONTRACT_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "계약서 파일이 존재하지 않습니다."),
     LEGALTAX_NOT_FOUND(HttpStatus.NOT_FOUND, "법률/세무 정보를 찾을 수 없습니다."),
+
     // 9. 업무현황 (CreatorWork)
     WORK_NOT_FOUND(HttpStatus.NOT_FOUND, "업무를 찾을 수 없습니다.");
 


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #189 


## 변경 내용
- serviceImpl updateSchedul 공통 로직 중 일반 일정, 크리에이터 일정 분기 나누어 처리 


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수