### PR TITLE
fix : add global error handling for vacation , change filter criteria…

### DIFF
--- a/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
@@ -32,14 +32,28 @@ public interface VacationRepository extends JpaRepository<Vacation, Long> {
                         @Param("endDate") LocalDate endDate,
                         @Param("type") VacationType type);
 
-        /** 관리자용 전체 휴가 목록 조회 (기간, 승인상태, 이름, 휴가유형 필터 적용) */
+        /** 관리자용 전체 휴가 목록 조회 (기간, 승인상태, 이름, 휴가유형 필터 적용) - 시작일 내림차순 */
         @Query("SELECT v FROM Vacation v " +
-                        "WHERE v.vacationRequest BETWEEN :startDate AND :endDate " +
+                        "WHERE v.vacationStart BETWEEN :startDate AND :endDate " +
                         "AND (:status IS NULL OR v.vacationApprove = :status) " +
                         "AND (:name IS NULL OR :name = '' OR v.member.memberName LIKE %:name%) " +
                         "AND (:type IS NULL OR v.vacationType = :type) " +
-                        "ORDER BY v.vacationRequest DESC")
+                        "ORDER BY v.vacationStart DESC")
         List<Vacation> findAllWithFilters(
+                        @Param("startDate") LocalDate startDate,
+                        @Param("endDate") LocalDate endDate,
+                        @Param("status") VacationApprove status,
+                        @Param("name") String name,
+                        @Param("type") VacationType type);
+
+        /** 관리자용 전체 휴가 목록 조회 (기간, 승인상태, 이름, 휴가유형 필터 적용) - 신청일 오름차순 (미승인용) */
+        @Query("SELECT v FROM Vacation v " +
+                        "WHERE v.vacationStart BETWEEN :startDate AND :endDate " +
+                        "AND (:status IS NULL OR v.vacationApprove = :status) " +
+                        "AND (:name IS NULL OR :name = '' OR v.member.memberName LIKE %:name%) " +
+                        "AND (:type IS NULL OR v.vacationType = :type) " +
+                        "ORDER BY v.vacationRequest ASC")
+        List<Vacation> findAllWithFiltersOrderByRequestAsc(
                         @Param("startDate") LocalDate startDate,
                         @Param("endDate") LocalDate endDate,
                         @Param("status") VacationApprove status,
@@ -96,4 +110,15 @@ public interface VacationRepository extends JpaRepository<Vacation, Long> {
         java.util.Optional<Vacation> findApprovedVacationByMemberAndDate(
                         @Param("memberId") Long memberId,
                         @Param("date") LocalDate date);
+
+        /** 특정 회원의 휴가 날짜 중복 확인 (반려 제외, 승인대기/승인됨만 확인) */
+        @Query("SELECT v FROM Vacation v " +
+                        "WHERE v.member.memberId = :memberId " +
+                        "AND v.vacationApprove != 'REJECTED' " +
+                        "AND v.vacationStart <= :endDate " +
+                        "AND v.vacationEnd >= :startDate")
+        List<Vacation> findOverlappingVacations(
+                        @Param("memberId") Long memberId,
+                        @Param("startDate") LocalDate startDate,
+                        @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/com/mcn/in4/domain/vacation/service/VacationAdminServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/service/VacationAdminServiceImpl.java
@@ -40,7 +40,10 @@ public class VacationAdminServiceImpl implements VacationAdminService {
             String name,
             VacationType type
     ) {
-        List<Vacation> vacations = vacationRepository.findAllWithFilters(startDate, endDate, status, name, type);
+        // 미승인(APPROVE_NEED)의 경우 신청일 오름차순(오래된 신청부터), 그 외는 내림차순
+        List<Vacation> vacations = (status == VacationApprove.APPROVE_NEED)
+                ? vacationRepository.findAllWithFiltersOrderByRequestAsc(startDate, endDate, status, name, type)
+                : vacationRepository.findAllWithFilters(startDate, endDate, status, name, type);
 
         return vacations.stream()
                 .map(vacation -> {

--- a/src/main/java/com/mcn/in4/domain/vacation/service/VacationServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/service/VacationServiceImpl.java
@@ -58,6 +58,21 @@ public class VacationServiceImpl implements VacationService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND, "회원 ID " + memberId + "를 찾을 수 없습니다."));
 
+        // 반차인 경우 종료일을 시작일과 동일하게 설정
+        LocalDate vacationEnd = (vacationType == VacationType.HALF)
+                ? request.getVacationStart()
+                : request.getVacationEnd();
+
+        // 휴가 날짜 중복 확인 (반려 제외, 승인대기/승인됨만 확인)
+        List<Vacation> overlappingVacations = vacationRepository.findOverlappingVacations(
+                memberId, request.getVacationStart(), vacationEnd);
+
+        if (!overlappingVacations.isEmpty()) {
+            Vacation overlap = overlappingVacations.get(0);
+            throw new CustomException(ErrorCode.VACATION_DATE_OVERLAP,
+                    "기존 휴가(" + overlap.getVacationStart() + " ~ " + overlap.getVacationEnd() + ")와 날짜가 겹칩니다.");
+        }
+
         // 휴가 일수 계산
         double vacationDays = calculateVacationDays(vacationType, request);
 
@@ -74,11 +89,6 @@ public class VacationServiceImpl implements VacationService {
             // 잔여 연차 차감
             employeeDetail.decreaseVacationRemainder(vacationDays);
         }
-
-        // 반차인 경우 종료일을 시작일과 동일하게 설정
-        LocalDate vacationEnd = (vacationType == VacationType.HALF)
-                ? request.getVacationStart()
-                : request.getVacationEnd();
 
         // 휴가 엔티티 생성
         Vacation vacation = Vacation.builder()

--- a/src/main/java/com/mcn/in4/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/mcn/in4/global/error/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     INVALID_VACATION_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 휴가 타입입니다."),
     VACATION_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, "휴가 타입별 필수 상세 정보가 누락되었습니다."),
     INVALID_VACATION_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서는 처리할 수 없는 요청입니다."),
+    VACATION_DATE_OVERLAP(HttpStatus.CONFLICT, "이미 신청한 휴가와 날짜가 겹칩니다."),
     // 7. 근태 (Attendance)
     ATTENDANCE_ALREADY_MARKED(HttpStatus.CONFLICT, "이미 오늘 출근 처리가 되었습니다."),
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "출근 기록을 찾을 수 없습니다."),


### PR DESCRIPTION


## 관련 이슈 번호
- Closes #191


## 변경 내용
- 기존 휴가신청일과 겹치는 날짜로 휴가 신청불가 로직 추가
- 기간필터 기준을 신청일이 아닌 시작일로 기준을 변경
- 미승인 필터 적용시 정렬기준 신청일로 수정