### PR TITLE
feat: 프로필 교체 구현 #223

### DIFF
--- a/src/main/java/com/mcn/in4/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mcn/in4/domain/member/controller/MemberController.java
@@ -45,4 +45,13 @@ public class MemberController {
         return ResponseEntity.ok(managers);
     }
 
+    @DeleteMapping("/delete")
+    public ResponseEntity<MemberProfileResponseDto> deleteProfile(
+            @AuthenticationPrincipal String userId
+    ){
+        Long memberId = Long.parseLong(userId);
+        MemberProfileResponseDto deleteProfile = memberService.deleteMemberProfile(memberId);
+        return ResponseEntity.ok(deleteProfile);
+    }
+
 }

--- a/src/main/java/com/mcn/in4/domain/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/mcn/in4/domain/member/repository/MemberProfileRepository.java
@@ -26,4 +26,6 @@ public interface MemberProfileRepository extends JpaRepository<MemberProfile, Lo
     @Query("update MemberProfile mp set mp.profileImage = :profileImage where mp.member.memberId = :memberId ")
     int updateProfileImage(@Param("memberId") Long memberId,
                            @Param("profileImage") String profileImage);
+
+    Optional<MemberProfile> findTopByMember_MemberId(Long memberId);
 }

--- a/src/main/java/com/mcn/in4/domain/member/service/MemberService.java
+++ b/src/main/java/com/mcn/in4/domain/member/service/MemberService.java
@@ -12,4 +12,6 @@ public interface MemberService {
 
     // 매니저 목록 조회
     List<ManagerResponseDto.ManagerInfo> getAllManagers();
+
+    MemberProfileResponseDto deleteMemberProfile(Long memberId);
 }

--- a/src/main/java/com/mcn/in4/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/member/service/MemberServiceImpl.java
@@ -15,8 +15,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.DeleteObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedDeleteObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -27,7 +30,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = false)
 public class MemberServiceImpl implements MemberService {
 
         private final MemberRepository memberRepository;
@@ -59,7 +62,7 @@ public class MemberServiceImpl implements MemberService {
                                 .memberName(member.getMemberName())
                                 .memberAccount(member.getMemberAccount())
                                 .memberRole(member.getMemberRole())
-                                .profileImage(profile.getProfileImage())
+                                .profileImage("https://" + bucket + ".s3." + region + ".amazonaws.com/" + profile.getProfileImage())
                                 .profileBanner(profile.getProfileBanner());
 
                 // 4. 직원인 경우 상세 정보 조회 및 추가
@@ -108,7 +111,7 @@ public class MemberServiceImpl implements MemberService {
 
         String viewUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3key;
 
-        memberProfileRepository.updateProfileImage(memberId, viewUrl);
+        memberProfileRepository.updateProfileImage(memberId, s3key);
 
         return MemberProfileResponseDto.builder()
                 .presignedURL(presignedUrl)
@@ -124,5 +127,30 @@ public class MemberServiceImpl implements MemberService {
         return managers.stream()
                 .map(ManagerResponseDto.ManagerInfo::from)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public MemberProfileResponseDto deleteMemberProfile(Long memberId){
+        MemberProfile deletedProfile = memberProfileRepository.findTopByMember_MemberId(memberId).orElseThrow();
+
+        String s3key = deletedProfile.getProfileImage();
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3key)
+                .build();
+
+        PresignedDeleteObjectRequest presignedDeleteObjectRequest = s3Presigner.presignDeleteObject(
+                DeleteObjectPresignRequest.builder()
+                        .deleteObjectRequest(deleteObjectRequest)
+                        .signatureDuration(Duration.ofMinutes(5))
+                        .build()
+        );
+
+        String presignedUrl = presignedDeleteObjectRequest.url().toString();
+
+        return MemberProfileResponseDto.builder()
+                .presignedURL(presignedUrl)
+                .build();
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #223


## 변경 내용
- 프로필 사진 불러오기 구현
- 프로필 사진 업로드 구현
- 프로필 사진 업로드 시 기존파일 삭제 구현

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수