### PR TITLE
fixt: move refresh token to httpOnly cookie #244

### DIFF
--- a/src/main/java/com/mcn/in4/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/mcn/in4/domain/auth/controller/AuthController.java
@@ -4,7 +4,15 @@ import com.mcn.in4.domain.auth.controller.api.AuthApi;
 import com.mcn.in4.domain.auth.dto.request.AuthRequestDTO;
 import com.mcn.in4.domain.auth.dto.response.AuthResponseDTO;
 import com.mcn.in4.domain.auth.service.AuthService;
+import com.mcn.in4.global.error.exception.CustomException;
+import com.mcn.in4.global.error.exception.ErrorCode;
+import com.mcn.in4.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -13,12 +21,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 /**
  * 인증 컨트롤러
  * - 로그인, 로그아웃, 토큰 재발급 API 제공
- * - JWT Access Token과 Refresh Token 기반 인증 처리
+ * - Access Token: Response Body로 반환
+ * - Refresh Token: HttpOnly Cookie로 설정 (XSS 공격 방어)
  */
 @RestController
 @RequestMapping("/api/auth")
@@ -26,49 +33,92 @@ import java.util.Map;
 public class AuthController implements AuthApi {
     private final AuthService authService;
 
+    /** 쿠키 Secure 옵션 (개발: false, 운영: true) */
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
+
     /**
      * 로그인 API
      * - 사번(memberAccount)과 비밀번호로 인증
-     * - 성공 시 Access Token(30분)과 Refresh Token(7일) 반환
+     * - Access Token은 Response Body로 반환
+     * - Refresh Token은 HttpOnly Cookie로 설정
      * @param request 로그인 요청 DTO (memberAccount, password)
-     * @return Access Token, Refresh Token 포함 응답
+     * @param response HttpServletResponse (쿠키 설정용)
+     * @return Access Token 포함 응답
      */
     @Override
     @PostMapping("/login")
-    public AuthResponseDTO login(@RequestBody AuthRequestDTO.loginRequestDto request) {
-        return authService.login(request);
+    public ResponseEntity<AuthResponseDTO> login(
+            @RequestBody AuthRequestDTO.loginRequestDto request,
+            HttpServletResponse response) {
+
+        AuthResponseDTO authResponse = authService.login(request);
+
+        // Refresh Token을 HttpOnly 쿠키로 설정
+        ResponseCookie cookie = CookieUtil.createRefreshTokenCookie(authResponse.getRefreshToken(), cookieSecure);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        // Response Body에는 Access Token만 반환
+        AuthResponseDTO responseBody = AuthResponseDTO.builder()
+                .accessToken(authResponse.getAccessToken())
+                .build();
+
+        return ResponseEntity.ok(responseBody);
     }
 
     /**
      * 로그아웃 API
      * - Redis에서 Refresh Token 삭제
+     * - Refresh Token 쿠키 제거
      * - SecurityContext 인증 정보 제거
-     * - 이후 해당 Refresh Token으로 재발급 불가
+     * @param response HttpServletResponse (쿠키 삭제용)
      * @return 로그아웃 완료 메시지
      */
     @Override
     @PostMapping("/logout")
-    public ResponseEntity<String> logout() {
+    public ResponseEntity<String> logout(HttpServletResponse response) {
         // SecurityContext에서 현재 인증된 사용자의 memberId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.getName() != null) {
             authService.logout(authentication.getName());
         }
+
+        // Refresh Token 쿠키 삭제
+        ResponseCookie deleteCookie = CookieUtil.deleteRefreshTokenCookie(cookieSecure);
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+
         return ResponseEntity.ok("로그아웃 되었습니다.");
     }
 
     /**
      * 토큰 재발급 API
-     * - Access Token 만료 시 Refresh Token으로 새 토큰 발급
-     * - Refresh Token Rotation: 새 Refresh Token도 함께 발급
-     * - Redis에 저장된 Refresh Token과 비교하여 유효성 검증
-     * @param request refreshToken을 담은 Map
-     * @return 새로운 Access Token, Refresh Token 포함 응답
+     * - HttpOnly 쿠키에서 Refresh Token 추출
+     * - 새 Access Token 발급 및 Refresh Token Rotation
+     * @param request HttpServletRequest (쿠키에서 Refresh Token 추출)
+     * @param response HttpServletResponse (새 쿠키 설정용)
+     * @return 새로운 Access Token 포함 응답
      */
     @Override
     @PostMapping("/reissue")
-    public AuthResponseDTO reissue(@RequestBody Map<String, String> request) {
-        String refreshToken = request.get("refreshToken");
-        return authService.reissue(refreshToken);
+    public ResponseEntity<AuthResponseDTO> reissue(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        // 쿠키에서 Refresh Token 추출
+        String refreshToken = CookieUtil.getRefreshTokenFromCookie(request)
+                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_INVALID, "Refresh Token이 없습니다."));
+
+        AuthResponseDTO authResponse = authService.reissue(refreshToken);
+
+        // 새 Refresh Token을 HttpOnly 쿠키로 설정 (Rotation)
+        ResponseCookie cookie = CookieUtil.createRefreshTokenCookie(authResponse.getRefreshToken(), cookieSecure);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        // Response Body에는 Access Token만 반환
+        AuthResponseDTO responseBody = AuthResponseDTO.builder()
+                .accessToken(authResponse.getAccessToken())
+                .build();
+
+        return ResponseEntity.ok(responseBody);
     }
 }

--- a/src/main/java/com/mcn/in4/domain/auth/controller/api/AuthApi.java
+++ b/src/main/java/com/mcn/in4/domain/auth/controller/api/AuthApi.java
@@ -9,9 +9,9 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-
-import java.util.Map;
 
 
 @Tag(name = "인증(Auth) 관리", description = "로그인 및 로그아웃을 담당하는 API입니다.")
@@ -19,13 +19,13 @@ public interface AuthApi {
 
     @Operation(
             summary = "로그인",
-            description = "사번과 비밀번호를 사용하여 Access Token과 Refresh Token을 발급받습니다.",
+            description = "사번과 비밀번호를 사용하여 Access Token을 발급받습니다. Refresh Token은 HttpOnly 쿠키로 설정됩니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "로그인 성공 및 토큰 발급"),
                     @ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호 불일치")
             }
     )
-    AuthResponseDTO login(
+    ResponseEntity<AuthResponseDTO> login(
             @RequestBody(
                     description = "로그인 정보",
                     content = @Content(
@@ -65,43 +65,27 @@ public interface AuthApi {
                                     )
                             }
                     )
-            ) AuthRequestDTO.loginRequestDto request
+            ) AuthRequestDTO.loginRequestDto request,
+            HttpServletResponse response
     );
 
     @Operation(
             summary = "로그아웃",
-            description = "현재 로그인된 세션을 종료합니다. Redis에서 Refresh Token을 삭제합니다.",
+            description = "현재 로그인된 세션을 종료합니다. Redis에서 Refresh Token을 삭제하고 쿠키를 제거합니다.",
             security = @SecurityRequirement(name = "JWT"),
             responses = {
                     @ApiResponse(responseCode = "200", description = "로그아웃 성공")
             }
     )
-    ResponseEntity<String> logout();
+    ResponseEntity<String> logout(HttpServletResponse response);
 
     @Operation(
             summary = "토큰 재발급",
-            description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다.",
+            description = "HttpOnly 쿠키의 Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
                     @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
             }
     )
-    AuthResponseDTO reissue(
-            @RequestBody(
-                    description = "Refresh Token",
-                    content = @Content(
-                            examples = {
-                                    @ExampleObject(
-                                            name = "토큰 재발급",
-                                            summary = "Refresh Token으로 재발급",
-                                            value = """
-                                                    {
-                                                      "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-                                                    }
-                                                    """
-                                    )
-                            }
-                    )
-            ) Map<String, String> request
-    );
+    ResponseEntity<AuthResponseDTO> reissue(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/mcn/in4/global/util/CookieUtil.java
+++ b/src/main/java/com/mcn/in4/global/util/CookieUtil.java
@@ -1,0 +1,66 @@
+package com.mcn.in4.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * 쿠키 유틸리티 클래스
+ * - HttpOnly 쿠키 생성 및 조회를 위한 헬퍼 메서드 제공
+ * - Refresh Token을 안전하게 저장하기 위해 사용
+ */
+public class CookieUtil {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final long REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60; // 7일 (초 단위)
+
+    /**
+     * Refresh Token용 HttpOnly 쿠키 생성
+     * @param refreshToken Refresh Token 값
+     * @param secure HTTPS 전용 여부 (개발: false, 운영: true)
+     * @return ResponseCookie 객체 (Set-Cookie 헤더에 사용)
+     */
+    public static ResponseCookie createRefreshTokenCookie(String refreshToken, boolean secure) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)           // JavaScript 접근 차단 (XSS 방어)
+                .secure(secure)           // HTTPS 전용 여부
+                .sameSite("Lax")          // 개발 환경 호환성을 위해 Lax 사용
+                .path("/api/auth")        // 인증 관련 경로에서만 전송
+                .maxAge(REFRESH_TOKEN_MAX_AGE)
+                .build();
+    }
+
+    /**
+     * Refresh Token 쿠키 삭제 (로그아웃 시 사용)
+     * @param secure HTTPS 전용 여부
+     * @return maxAge=0인 ResponseCookie (브라우저에서 쿠키 삭제)
+     */
+    public static ResponseCookie deleteRefreshTokenCookie(boolean secure) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax")
+                .path("/api/auth")
+                .maxAge(0)  // 즉시 만료
+                .build();
+    }
+
+    /**
+     * 요청에서 Refresh Token 쿠키 값 추출
+     * @param request HttpServletRequest
+     * @return Refresh Token 값 (Optional)
+     */
+    public static Optional<String> getRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #244 


## 변경 내용
- 내용
refresh 토큰을 로컬이 아닌 httpOnly를 통해 쿠기에 저장하여 보안성을 높인다.
-작업
로컬에 refresh 토큰을 저장하여 refresh 토큰 rotation을 써도 해커가 사용자보다 먼저 발급을 받을시 문제가 생겨 refresh을 쿠기에 저장시켜 xss공격을 막아 보안성을 높인다.