### PR TITLE
feat: vacation

### DIFF
--- a/src/main/java/com/mcn/in4/domain/ai/dto/member/MemberQuery.java
+++ b/src/main/java/com/mcn/in4/domain/ai/dto/member/MemberQuery.java
@@ -1,0 +1,10 @@
+package com.mcn.in4.domain.ai.dto.member;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+@JsonClassDescription("직원 검색 요청. 이름, 부서명, 직무 등으로 검색 가능.")
+public record MemberQuery(
+        @JsonPropertyDescription("검색할 직원의 이름 (부분 일치 가능). 예: '김철수', '김'") String name,
+        @JsonPropertyDescription("검색할 부서명 (부분 일치 가능). 예: '마케팅', '개발'") String departmentName) {
+}

--- a/src/main/java/com/mcn/in4/domain/ai/dto/member/MemberSummaryResult.java
+++ b/src/main/java/com/mcn/in4/domain/ai/dto/member/MemberSummaryResult.java
@@ -1,0 +1,8 @@
+package com.mcn.in4.domain.ai.dto.member;
+
+import java.util.List;
+
+public record MemberSummaryResult(
+        String message,
+        List<String> records) {
+}

--- a/src/main/java/com/mcn/in4/domain/ai/dto/vacation/VacationQuery.java
+++ b/src/main/java/com/mcn/in4/domain/ai/dto/vacation/VacationQuery.java
@@ -1,0 +1,12 @@
+package com.mcn.in4.domain.ai.dto.vacation;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+@JsonClassDescription("휴가 조회 요청. 구체적 날짜는 startDate/endDate(YYYY-MM-DD)를 사용하고, 상대적 표현은 dateInfo를 사용.")
+public record VacationQuery(
+                @JsonPropertyDescription("조회 시작 날짜 (YYYY-MM-DD). 연도 미명시 시 2026년 기준.") String startDate,
+                @JsonPropertyDescription("조회 종료 날짜 (YYYY-MM-DD). 연도 미명시 시 2026년 기준.") String endDate,
+                @JsonPropertyDescription("상대적 기간: TODAY, THIS_WEEK, LAST_WEEK, THIS_MONTH, LAST_MONTH, THIS_YEAR. 잔여 연차 조회나 연간 내역 조회 시에는 THIS_YEAR를 사용.") String dateInfo,
+                @JsonPropertyDescription("검색할 타인의 이름. '나', '본인', '내' 등 자기 지칭은 넣지 말 것. 타인 이름 언급 시에만 설정하고 getAllVacationSummary를 호출.") String targetName) {
+}

--- a/src/main/java/com/mcn/in4/domain/ai/dto/vacation/VacationSummary.java
+++ b/src/main/java/com/mcn/in4/domain/ai/dto/vacation/VacationSummary.java
@@ -1,0 +1,9 @@
+package com.mcn.in4.domain.ai.dto.vacation;
+
+import java.util.List;
+
+public record VacationSummary(
+        String memberId,
+        String message,
+        List<String> records) {
+}

--- a/src/main/java/com/mcn/in4/domain/ai/service/AiChatServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/ai/service/AiChatServiceImpl.java
@@ -37,9 +37,10 @@ public class AiChatServiceImpl implements AiChatService {
    * - CREATOR 등 맵에 없는 역할은 도구 없음 (빈 리스트 적용)
    */
   private static final Map<String, List<String>> ROLE_TOOLS = Map.of(
-      "ADMINISTRATOR", List.of("getMyAttendanceSummary", "getAllAttendanceSummary"),
-      "MANAGER", List.of("getMyAttendanceSummary"),
-      "EMPLOYEE", List.of("getMyAttendanceSummary")
+      "ADMINISTRATOR", List.of("getMyAttendanceSummary", "getAllAttendanceSummary",
+          "getMyVacationSummary", "getAllVacationSummary", "searchMember"),
+      "MANAGER", List.of("getMyAttendanceSummary", "getMyVacationSummary", "searchMember"),
+      "EMPLOYEE", List.of("getMyAttendanceSummary", "getMyVacationSummary", "searchMember")
   // CREATOR → 맵에 없음 = 도구 없음
   );
 
@@ -77,14 +78,21 @@ public class AiChatServiceImpl implements AiChatService {
           [날짜 규칙]
           - 연도 미명시 시 2026년 기준
           - 구체적 날짜(N월 N일)는 startDate/endDate에 YYYY-MM-DD로 변환
+          - 구체적 날짜(N월 N일)는 startDate/endDate에 YYYY-MM-DD로 변환
           - 상대적 표현(이번주, 저번달 등)은 dateInfo 필드 사용
+          - 잔여 연차나 연간 내역 질문 시 dateInfo='THIS_YEAR' 사용
 
           [권한]
           %s
 
+          [도구 사용 규칙]
+          - 근태 조회: '나'의 근태는 getMyAttendanceSummary, 타인은 getAllAttendanceSummary 사용
+          - 휴가 조회: '나'의 휴가/잔여 연차는 getMyVacationSummary, 타인은 getAllVacationSummary 사용
+          - 직원 검색: 이름이나 부서로 직원 정보를 찾을 때 searchMember 사용
+
           [응답 규칙]
-          - 도구 결과를 마크다운 표로 정리
-          - 도구 호출 없이 근태 데이터를 추측하거나 만들어내지 마세요
+          - 도구 결과를 마크다운 표로 정리 (표 앞에는 반드시 빈 줄 추가)
+          - 도구 호출 없이 근태/휴가 데이터를 추측하거나 만들어내지 마세요
           - 권한 없음, 오류 등 거부 응답은 한 문장으로 간결하게 (대안 제시나 절차 설명 금지)
           """.formatted(LocalDate.now(), roleGuideline);
 
@@ -124,8 +132,9 @@ public class AiChatServiceImpl implements AiChatService {
       }
 
       // 기타 AI 오류
+      // 사용자에게는 친절한 메시지 반환, 상세 로그는 서버에 기록됨
       throw new CustomException(ErrorCode.AI_SERVICE_ERROR,
-          "AI 응답 생성 실패: " + e.getMessage());
+          "AI 서비스 처리 중 일시적인 오류가 발생했습니다. 관리자에게 문의하거나 잠시 후 다시 시도해주세요.");
     }
   }
 

--- a/src/main/java/com/mcn/in4/domain/ai/tools/MemberTools.java
+++ b/src/main/java/com/mcn/in4/domain/ai/tools/MemberTools.java
@@ -1,0 +1,96 @@
+package com.mcn.in4.domain.ai.tools;
+
+import com.mcn.in4.domain.ai.dto.member.MemberQuery;
+import com.mcn.in4.domain.ai.dto.member.MemberSummaryResult;
+import com.mcn.in4.domain.member.dto.MemberSummaryDto;
+import com.mcn.in4.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 직원 검색 AI 도구
+ * - searchMember: 이름이나 부서명으로 직원 검색 (EMPLOYEE, MANAGER, ADMINISTRATOR)
+ * - 크리에이터(CREATOR)는 ROLE_TOOLS 맵에서 제외되어 접근 불가
+ * - 반환 정보: 이름, 부서, 직무, 역할 (민감정보 미포함)
+ */
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MemberTools {
+
+    private final MemberService memberService;
+
+    // ===== 인증 정보 추출 =====
+    private Authentication getAuthOrThrow() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalStateException("로그인이 필요한 서비스입니다.");
+        }
+        return auth;
+    }
+
+    // ===== 직원 검색 도구 =====
+    @Bean
+    @Description("직원을 이름이나 부서명으로 검색합니다. 예: '마케팅팀 팀장이 누구야?', '김철수 어느 부서야?'")
+    public Function<MemberQuery, MemberSummaryResult> searchMember() {
+        return query -> {
+            Authentication auth = getAuthOrThrow();
+            log.info("AI 직원 검색 요청 - 이름: {}, 부서: {}, 요청자: {}",
+                    query.name(), query.departmentName(), auth.getName());
+
+            List<MemberSummaryDto> allMembers = memberService.getAllMembers();
+
+            // 이름 또는 부서 필터링
+            List<MemberSummaryDto> filtered = allMembers.stream()
+                    .filter(m -> {
+                        boolean nameMatch = true;
+                        boolean deptMatch = true;
+
+                        if (query.name() != null && !query.name().isBlank()) {
+                            nameMatch = m.getMemberName() != null
+                                    && m.getMemberName().contains(query.name().trim());
+                        }
+                        if (query.departmentName() != null && !query.departmentName().isBlank()) {
+                            deptMatch = m.getDepartmentName() != null
+                                    && m.getDepartmentName().contains(query.departmentName().trim());
+                        }
+                        return nameMatch && deptMatch;
+                    })
+                    .collect(Collectors.toList());
+
+            log.info("AI 직원 검색 결과: {}건", filtered.size());
+
+            List<String> records = filtered.stream()
+                    .map(m -> String.format("이름: %s, 부서: %s, 직무: %s, 역할: %s, 상태: %s",
+                            m.getMemberName(),
+                            m.getDepartmentName() != null ? m.getDepartmentName() : "-",
+                            m.getTask() != null ? m.getTask() : "-",
+                            m.getMemberRole() != null ? m.getMemberRole().name() : "-",
+                            m.getMemberStatus() != null ? m.getMemberStatus().name() : "-"))
+                    .collect(Collectors.toList());
+
+            String message;
+            if (records.isEmpty()) {
+                String searchTerm = "";
+                if (query.name() != null && !query.name().isBlank())
+                    searchTerm += "이름='" + query.name() + "' ";
+                if (query.departmentName() != null && !query.departmentName().isBlank())
+                    searchTerm += "부서='" + query.departmentName() + "'";
+                message = String.format("검색 조건(%s)에 해당하는 직원을 찾을 수 없습니다.", searchTerm.trim());
+            } else {
+                message = String.format("총 %d명의 직원이 검색되었습니다.", records.size());
+            }
+
+            return new MemberSummaryResult(message, records);
+        };
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/ai/tools/VacationTools.java
+++ b/src/main/java/com/mcn/in4/domain/ai/tools/VacationTools.java
@@ -1,0 +1,267 @@
+package com.mcn.in4.domain.ai.tools;
+
+import com.mcn.in4.domain.ai.dto.vacation.VacationQuery;
+import com.mcn.in4.domain.ai.dto.vacation.VacationSummary;
+import com.mcn.in4.domain.ai.service.AiChatServiceImpl;
+import com.mcn.in4.domain.vacation.dto.response.AdminVacationListResponseDTO;
+import com.mcn.in4.domain.vacation.dto.response.VacationListResponseDTO;
+import com.mcn.in4.domain.vacation.dto.response.VacationRemainderResponseDTO;
+import com.mcn.in4.domain.vacation.service.VacationAdminService;
+import com.mcn.in4.domain.vacation.service.VacationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 휴가 관련 AI 도구
+ * - getMyVacationSummary: 본인의 잔여 연차 및 휴가 내역 조회 (EMPLOYEE, MANAGER,
+ * ADMINISTRATOR)
+ * - getAllVacationSummary: 전체/특정 직원 휴가 조회 (ADMINISTRATOR 전용)
+ * - 크리에이터(CREATOR)는 ROLE_TOOLS 맵에서 제외되어 접근 불가
+ */
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class VacationTools {
+
+    private final VacationService vacationService;
+    private final VacationAdminService vacationAdminService;
+
+    /** 자기 지칭 단어 목록 — targetName에 들어오면 null로 처리 */
+    private static final Set<String> SELF_REFERENCES = Set.of(
+            "나", "내", "본인", "저", "나의", "내꺼", "제", "자신");
+
+    // ===== 인증 정보 추출 공통 메서드 =====
+    private Authentication getAuthOrThrow() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalStateException("로그인이 필요한 서비스입니다.");
+        }
+        return auth;
+    }
+
+    private boolean hasRole(Authentication auth, String role) {
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(a -> a.equals("ROLE_" + role));
+    }
+
+    // ===== 날짜 범위 계산 공통 메서드 =====
+    private LocalDate[] resolveDateRange(VacationQuery query) {
+        LocalDate start = null;
+        LocalDate end = null;
+
+        if (query.dateInfo() != null && !query.dateInfo().isBlank()) {
+            String info = query.dateInfo().toUpperCase().replace(" ", "_");
+            LocalDate now = LocalDate.now();
+
+            switch (info) {
+                case "TODAY" -> {
+                    start = now;
+                    end = now;
+                }
+                case "THIS_WEEK" -> {
+                    start = now.with(DayOfWeek.MONDAY);
+                    end = now;
+                }
+                case "LAST_WEEK" -> {
+                    start = now.minusWeeks(1).with(DayOfWeek.MONDAY);
+                    end = now.minusWeeks(1).with(DayOfWeek.SUNDAY);
+                }
+                case "THIS_MONTH" -> {
+                    start = now.withDayOfMonth(1);
+                    end = now.withDayOfMonth(now.lengthOfMonth());
+                }
+                case "LAST_MONTH" -> {
+                    start = now.minusMonths(1).withDayOfMonth(1);
+                    end = now.minusMonths(1).withDayOfMonth(now.minusMonths(1).lengthOfMonth());
+                }
+                case "THIS_YEAR" -> {
+                    start = now.withDayOfYear(1);
+                    end = now.withDayOfYear(now.lengthOfYear());
+                }
+                default -> log.warn("Unknown dateInfo: {}", info);
+            }
+        }
+
+        if (start == null)
+            start = parseDate(query.startDate());
+        if (end == null)
+            end = parseDate(query.endDate());
+
+        // 기본값: 올해 전체
+        if (start == null)
+            start = LocalDate.now().withDayOfMonth(1).withMonth(1);
+        if (end == null)
+            end = LocalDate.now().withDayOfMonth(31).withMonth(12);
+
+        return new LocalDate[] { start, end };
+    }
+
+    // ===== 내 휴가 조회 도구 =====
+    @Bean
+    @Description("본인의 잔여 연차와 휴가 사용 내역을 조회합니다. 주어가 '나'일 때만 사용.")
+    public Function<VacationQuery, VacationSummary> getMyVacationSummary() {
+        return query -> {
+            Authentication auth = getAuthOrThrow();
+
+            // 자기 지칭("나", "본인" 등)은 targetName에서 무시
+            String targetName = query.targetName();
+            if (targetName != null && SELF_REFERENCES.contains(targetName.trim())) {
+                log.info("자기 지칭 targetName='{}' 무시 처리", targetName);
+                targetName = null;
+            }
+
+            // 타 직원 조회 시도 차단
+            if (targetName != null && !targetName.isBlank()) {
+                log.warn("getMyVacationSummary에 targetName='{}' 전달됨 - 권한 없음으로 차단", targetName);
+                AttendanceTools.DENIED_MESSAGE.set(AiChatServiceImpl.MSG_NO_PERMISSION);
+                return new VacationSummary(auth.getName(), AiChatServiceImpl.MSG_NO_PERMISSION, List.of());
+            }
+
+            Long currentMemberId;
+            try {
+                currentMemberId = Long.parseLong(auth.getName());
+            } catch (NumberFormatException e) {
+                log.error("Invalid user ID in security context", e);
+                return new VacationSummary("Unknown", "사용자 정보를 확인할 수 없습니다.", List.of());
+            }
+
+            // 잔여 연차 조회
+            VacationRemainderResponseDTO remainder = vacationService.getMyVacationRemainder(currentMemberId);
+
+            // 휴가 내역 조회
+            LocalDate[] range = resolveDateRange(query);
+            List<VacationListResponseDTO> vacations = vacationService.getMyVacations(
+                    currentMemberId, range[0], range[1], null);
+
+            log.info("AI requesting MY vacation for memberId: {}, range: {} ~ {}, found: {}건",
+                    currentMemberId, range[0], range[1], vacations.size());
+
+            // 잔여 연차 정보 포맷
+            String remainderInfo = String.format("총 연차: %.1f일, 사용: %.1f일, 잔여: %.1f일",
+                    remainder.getTotalVacation(),
+                    remainder.getUsedVacation(),
+                    remainder.getVacationRemainder());
+
+            // 휴가 내역 포맷
+            List<String> records = vacations.stream()
+                    .map(v -> String.format("[%s] %s, 사용일수: %.1f일, 사유: %s, 상태: %s",
+                            v.getVacationPeriod(),
+                            translateType(v.getVacationType()),
+                            v.getVacationDays(),
+                            v.getVacationDetail() != null ? v.getVacationDetail() : "-",
+                            translateApprove(v.getVacationApprove())))
+                    .collect(Collectors.toList());
+
+            String message = records.isEmpty()
+                    ? remainderInfo
+                    : String.format("%s | %s ~ %s 기간 총 %d건의 휴가 기록이 있습니다.", remainderInfo, range[0], range[1],
+                            records.size());
+
+            return new VacationSummary(String.valueOf(currentMemberId), message, records);
+        };
+    }
+
+    // ===== 전체 직원 휴가 조회 도구 (관리자 전용) =====
+    @Bean
+    @Description("전체 또는 특정 직원의 휴가를 조회합니다. 관리자 전용. 특정 이름 언급 시 targetName에 이름을 넣어 호출.")
+    public Function<VacationQuery, VacationSummary> getAllVacationSummary() {
+        return query -> {
+            Authentication auth = getAuthOrThrow();
+
+            // 관리자 권한 확인
+            if (!hasRole(auth, "ADMINISTRATOR")) {
+                log.warn("Non-admin user {} attempted to access all vacations", auth.getName());
+                return new VacationSummary(auth.getName(),
+                        AiChatServiceImpl.MSG_NO_PERMISSION, List.of());
+            }
+
+            LocalDate[] range = resolveDateRange(query);
+
+            log.info("AI requesting ALL vacation by admin: {}, targetName: {}, range: {} ~ {}",
+                    auth.getName(), query.targetName(), range[0], range[1]);
+
+            // 관리자용 전체 휴가 조회 (이름 검색 지원)
+            Page<AdminVacationListResponseDTO> resultPage = vacationAdminService.getVacationList(
+                    range[0], range[1], null, query.targetName(), null,
+                    PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "vacationStart")));
+
+            List<String> records = resultPage.getContent().stream()
+                    .map(v -> {
+                        String period = v.getVacationStart().equals(v.getVacationEnd())
+                                ? v.getVacationStart().toString()
+                                : v.getVacationStart() + " ~ " + v.getVacationEnd();
+                        return String.format("[%s] %s - 유형: %s, 사용일수: %.1f일, 잔여: %.1f일, 상태: %s",
+                                period,
+                                v.getMemberName() != null ? v.getMemberName() : "이름없음",
+                                translateType(v.getVacationType()),
+                                v.getVacationDays(),
+                                v.getVacationRemainder() != null ? v.getVacationRemainder() : 0.0,
+                                translateApprove(v.getVacationApprove()));
+                    })
+                    .collect(Collectors.toList());
+
+            String message;
+            if (records.isEmpty()) {
+                message = (query.targetName() != null)
+                        ? String.format("'%s'님의 %s ~ %s 기간 휴가 기록이 없습니다.", query.targetName(), range[0], range[1])
+                        : String.format("%s ~ %s 기간에 조회된 전체 직원 휴가 기록이 없습니다.", range[0], range[1]);
+            } else {
+                message = (query.targetName() != null)
+                        ? String.format("'%s'님의 %s ~ %s 기간 휴가 기록 %d건입니다.", query.targetName(), range[0], range[1],
+                                records.size())
+                        : String.format("%s ~ %s 기간 전체 직원 총 %d건의 휴가 기록이 있습니다.", range[0], range[1], records.size());
+            }
+
+            return new VacationSummary(auth.getName(), message, records);
+        };
+    }
+
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.isBlank() || "null".equalsIgnoreCase(dateStr)) {
+            return null;
+        }
+        try {
+            if (dateStr.contains("-")) {
+                return LocalDate.parse(dateStr);
+            }
+            return LocalDate.parse(dateStr, DateTimeFormatter.BASIC_ISO_DATE);
+        } catch (Exception e) {
+            log.warn("Failed to parse date: {}", dateStr);
+            return LocalDate.now();
+        }
+    }
+
+    private String translateType(String typeStr) {
+        try {
+            return com.mcn.in4.domain.vacation.entity.enums.VacationType.valueOf(typeStr).getDescription();
+        } catch (IllegalArgumentException e) {
+            return typeStr;
+        }
+    }
+
+    private String translateApprove(String approveStr) {
+        try {
+            return com.mcn.in4.domain.vacation.entity.enums.VacationApprove.valueOf(approveStr).getDescription();
+        } catch (IllegalArgumentException e) {
+            return approveStr;
+        }
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/vacation/entity/enums/VacationApprove.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/entity/enums/VacationApprove.java
@@ -4,7 +4,17 @@ package com.mcn.in4.domain.vacation.entity.enums;
  * 휴가 승인 상태
  */
 public enum VacationApprove {
-    APPROVE_NEED, // 승인 대기
-    APPROVED,     // 승인됨
-    REJECTED      // 반려됨
+    APPROVE_NEED("승인 대기"),
+    APPROVED("승인됨"),
+    REJECTED("반려됨");
+
+    private final String description;
+
+    VacationApprove(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #251 


## 변경 내용
- 권한에 따른 휴가 조회 기능 추가. 
- 크리에이터 X, 일반직원은 타인 X, 관리 직원은 전체 가능.

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수