### PR TITLE
feat: chatBot schedule search

### DIFF
--- a/src/main/java/com/mcn/in4/domain/ai/dto/schedule/ScheduleQuery.java
+++ b/src/main/java/com/mcn/in4/domain/ai/dto/schedule/ScheduleQuery.java
@@ -1,0 +1,15 @@
+package com.mcn.in4.domain.ai.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ScheduleQuery(
+        @JsonPropertyDescription("조회 시작 날짜 (YYYY-MM-DD), dateInfo가 있으면 생략 가능") String startDate,
+
+        @JsonPropertyDescription("조회 종료 날짜 (YYYY-MM-DD), dateInfo가 있으면 생략 가능") String endDate,
+
+        @JsonPropertyDescription("상대적 날짜 표현 (TODAY, THIS_WEEK, NEXT_WEEK, THIS_MONTH, LAST_MONTH, THIS_YEAR)") String dateInfo,
+
+        @JsonPropertyDescription("조회 대상 이름 (크리에이터 일정 조회 시 사용, 내 일정 조회 시 생략)") String targetName) {
+}

--- a/src/main/java/com/mcn/in4/domain/ai/dto/schedule/ScheduleSummary.java
+++ b/src/main/java/com/mcn/in4/domain/ai/dto/schedule/ScheduleSummary.java
@@ -1,0 +1,9 @@
+package com.mcn.in4.domain.ai.dto.schedule;
+
+import java.util.List;
+
+public record ScheduleSummary(
+        String targetName,
+        String message,
+        List<String> schedules) {
+}

--- a/src/main/java/com/mcn/in4/domain/ai/service/AiChatServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/ai/service/AiChatServiceImpl.java
@@ -38,11 +38,11 @@ public class AiChatServiceImpl implements AiChatService {
    */
   private static final Map<String, List<String>> ROLE_TOOLS = Map.of(
       "ADMINISTRATOR", List.of("getMyAttendanceSummary", "getAllAttendanceSummary",
-          "getMyVacationSummary", "getAllVacationSummary", "searchMember"),
-      "MANAGER", List.of("getMyAttendanceSummary", "getMyVacationSummary", "searchMember"),
-      "EMPLOYEE", List.of("getMyAttendanceSummary", "getMyVacationSummary", "searchMember")
-  // CREATOR → 맵에 없음 = 도구 없음
-  );
+          "getMyVacationSummary", "getAllVacationSummary", "searchMember", "getMySchedule"),
+      "MANAGER", List.of("getMyAttendanceSummary", "getMyVacationSummary", "searchMember",
+          "getMySchedule", "getCreatorSchedule"),
+      "EMPLOYEE", List.of("getMyAttendanceSummary", "getMyVacationSummary", "searchMember", "getMySchedule"),
+      "CREATOR", List.of("getCreatorSchedule"));
 
   @Override
   @Transactional
@@ -78,7 +78,6 @@ public class AiChatServiceImpl implements AiChatService {
           [날짜 규칙]
           - 연도 미명시 시 2026년 기준
           - 구체적 날짜(N월 N일)는 startDate/endDate에 YYYY-MM-DD로 변환
-          - 구체적 날짜(N월 N일)는 startDate/endDate에 YYYY-MM-DD로 변환
           - 상대적 표현(이번주, 저번달 등)은 dateInfo 필드 사용
           - 잔여 연차나 연간 내역 질문 시 dateInfo='THIS_YEAR' 사용
 
@@ -89,10 +88,13 @@ public class AiChatServiceImpl implements AiChatService {
           - 근태 조회: '나'의 근태는 getMyAttendanceSummary, 타인은 getAllAttendanceSummary 사용
           - 휴가 조회: '나'의 휴가/잔여 연차는 getMyVacationSummary, 타인은 getAllVacationSummary 사용
           - 직원 검색: 이름이나 부서로 직원 정보를 찾을 때 searchMember 사용
+          - 일정 조회:
+            1. '나'의 일정(개인/회사)은 getMySchedule 사용 (크리에이터 사용 불가)
+            2. '크리에이터' 또는 '담당 크리에이터'의 일정(방송/콘텐츠)은 getCreatorSchedule 사용
 
           [응답 규칙]
           - 도구 결과를 마크다운 표로 정리 (표 앞에는 반드시 빈 줄 추가)
-          - 도구 호출 없이 근태/휴가 데이터를 추측하거나 만들어내지 마세요
+          - 도구 호출 없이 근태/휴가/일정 데이터를 추측하거나 만들어내지 마세요
           - 권한 없음, 오류 등 거부 응답은 한 문장으로 간결하게 (대안 제시나 절차 설명 금지)
           """.formatted(LocalDate.now(), roleGuideline);
 

--- a/src/main/java/com/mcn/in4/domain/ai/tools/ScheduleTools.java
+++ b/src/main/java/com/mcn/in4/domain/ai/tools/ScheduleTools.java
@@ -1,0 +1,211 @@
+package com.mcn.in4.domain.ai.tools;
+
+import com.mcn.in4.domain.ai.dto.schedule.ScheduleQuery;
+import com.mcn.in4.domain.ai.dto.schedule.ScheduleSummary;
+import com.mcn.in4.domain.member.entity.memberEnum.MemberRole;
+import com.mcn.in4.domain.schedule.dto.responseDTO.SchedulReponseDTO;
+import com.mcn.in4.domain.schedule.service.SchedulService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ScheduleTools {
+
+    private final SchedulService schedulService;
+
+    @Bean
+    @Description("일반 직원, 매니저, 관리자의 '나의 일정'(개인/회사)을 조회합니다. (크리에이터 사용 불가)")
+    public Function<ScheduleQuery, ScheduleSummary> getMySchedule() {
+        return query -> {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            String role = auth.getAuthorities().iterator().next().getAuthority();
+            Long memberId = Long.parseLong(auth.getName());
+
+            // 크리에이터는 '나의 일정(개인/회사)' 조회 불가
+            if ("ROLE_CREATOR".equals(role)) {
+                return new ScheduleSummary("나", "크리에이터는 '나의 일정'을 조회할 수 없습니다. '크리에이터 일정'을 조회해주세요.", List.of());
+            }
+
+            LocalDate[] range = resolveDateRange(query);
+            LocalDate start = range[0];
+            LocalDate end = range[1];
+
+            List<String> months = getMonthsBetween(start, end);
+            List<SchedulReponseDTO.ScheduleResponseDto> allSchedules = new ArrayList<>();
+
+            for (String month : months) {
+                try {
+                    allSchedules.addAll(schedulService.getMyMonthlySchedules(memberId, month));
+                } catch (Exception e) {
+                    log.warn("Failed to fetch schedules for month {}: {}", month, e.getMessage());
+                }
+            }
+
+            List<String> validSchedules = allSchedules.stream()
+                    .filter(s -> !s.getScheduleDate().isBefore(start) && !s.getScheduleDate().isAfter(end))
+                    .sorted((s1, s2) -> s1.getScheduleDate().compareTo(s2.getScheduleDate()))
+                    .map(s -> String.format("[%s] (%s) %s %s",
+                            s.getScheduleDate(),
+                            s.getScheduleType().getDescription(),
+                            s.getScheduleName(),
+                            s.getScheduleDetail() != null ? "- " + s.getScheduleDetail() : ""))
+                    .toList();
+
+            String message = validSchedules.isEmpty()
+                    ? String.format("%s ~ %s 기간 동안 등록된 일정이 없습니다.", start, end)
+                    : String.format("%s ~ %s 기간 동안 총 %d건의 일정이 있습니다.", start, end, validSchedules.size());
+
+            return new ScheduleSummary("나", message, validSchedules);
+        };
+    }
+
+    @Bean
+    @Description("크리에이터(본인) 및 매니저(담당)의 '크리에이터 일정'(방송/콘텐츠 등)을 조회합니다.")
+    public Function<ScheduleQuery, ScheduleSummary> getCreatorSchedule() {
+        return query -> {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            String role = auth.getAuthorities().iterator().next().getAuthority();
+            Long memberId = Long.parseLong(auth.getName());
+
+            // 관리자 및 접근 권한 없는 역할 체크 (이미 ROLE_TOOLS에서 걸러지긴 하지만 이중 체크)
+            if (!"ROLE_CREATOR".equals(role) && !"ROLE_MANAGER".equals(role)) {
+                return new ScheduleSummary("크리에이터", "권한이 없습니다. 매니저 또는 크리에이터만 조회 가능합니다.", List.of());
+            }
+
+            LocalDate[] range = resolveDateRange(query);
+            LocalDate start = range[0];
+            LocalDate end = range[1];
+
+            List<String> months = getMonthsBetween(start, end);
+            List<SchedulReponseDTO.ScheduleResponseDto> allSchedules = new ArrayList<>();
+
+            for (String month : months) {
+                try {
+                    allSchedules.addAll(schedulService.getCreatorSchedules(memberId, role, month));
+                } catch (Exception e) {
+                    log.warn("Failed to fetch creator schedules for month {}: {}", month, e.getMessage());
+                }
+            }
+
+            Stream<SchedulReponseDTO.ScheduleResponseDto> stream = allSchedules.stream()
+                    .filter(s -> !s.getScheduleDate().isBefore(start) && !s.getScheduleDate().isAfter(end));
+
+            // 매니저가 특정 크리에이터 이름을 지정한 경우 필터링
+            if ("ROLE_MANAGER".equals(role) && query.targetName() != null && !query.targetName().isBlank()) {
+                String target = query.targetName().trim();
+                stream = stream.filter(s -> s.getCreatorName() != null && s.getCreatorName().contains(target));
+            }
+
+            List<String> validSchedules = stream
+                    .sorted((s1, s2) -> s1.getScheduleDate().compareTo(s2.getScheduleDate()))
+                    .map(s -> String.format("[%s] [%s] (%s) %s %s",
+                            s.getScheduleDate(),
+                            s.getCreatorName() != null ? s.getCreatorName() : "미지정",
+                            s.getScheduleType().getDescription(),
+                            s.getScheduleName(),
+                            s.getScheduleDetail() != null ? "- " + s.getScheduleDetail() : ""))
+                    .toList();
+
+            String targetDisplay = query.targetName() != null ? query.targetName() : "담당 크리에이터";
+            String message = validSchedules.isEmpty()
+                    ? String.format("%s ~ %s 기간 동안 %s의 일정이 없습니다.", start, end, targetDisplay)
+                    : String.format("%s ~ %s 기간 동안 %s의 총 %d건의 일정이 있습니다.", start, end, targetDisplay,
+                            validSchedules.size());
+
+            return new ScheduleSummary(targetDisplay, message, validSchedules);
+        };
+    }
+
+    private LocalDate[] resolveDateRange(ScheduleQuery query) {
+        LocalDate start = null;
+        LocalDate end = null;
+
+        if (query.dateInfo() != null && !query.dateInfo().isBlank()) {
+            String info = query.dateInfo().toUpperCase().replace(" ", "_");
+            LocalDate now = LocalDate.now();
+
+            switch (info) {
+                case "TODAY" -> {
+                    start = now;
+                    end = now;
+                }
+                case "THIS_WEEK" -> {
+                    start = now.with(java.time.DayOfWeek.MONDAY);
+                    end = now.with(java.time.DayOfWeek.SUNDAY);
+                }
+                case "NEXT_WEEK" -> {
+                    start = now.plusWeeks(1).with(java.time.DayOfWeek.MONDAY);
+                    end = now.plusWeeks(1).with(java.time.DayOfWeek.SUNDAY);
+                }
+                case "THIS_MONTH" -> {
+                    start = now.withDayOfMonth(1);
+                    end = now.withDayOfMonth(now.lengthOfMonth());
+                }
+                case "LAST_MONTH" -> {
+                    start = now.minusMonths(1).withDayOfMonth(1);
+                    end = now.minusMonths(1).withDayOfMonth(now.minusMonths(1).lengthOfMonth());
+                }
+                case "THIS_YEAR" -> {
+                    start = now.withDayOfYear(1);
+                    end = now.withDayOfYear(now.lengthOfYear());
+                }
+            }
+        }
+
+        if (start == null)
+            start = parseDate(query.startDate());
+        if (end == null)
+            end = parseDate(query.endDate());
+
+        // 기본값: 오늘 ~ 이번달 말
+        if (start == null)
+            start = LocalDate.now();
+        if (end == null)
+            end = start.withDayOfMonth(start.lengthOfMonth());
+
+        return new LocalDate[] { start, end };
+    }
+
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.isBlank() || "null".equalsIgnoreCase(dateStr)) {
+            return null;
+        }
+        try {
+            if (dateStr.contains("-")) {
+                return LocalDate.parse(dateStr);
+            }
+            return LocalDate.parse(dateStr, DateTimeFormatter.BASIC_ISO_DATE);
+        } catch (Exception e) {
+            log.warn("Failed to parse date: {}", dateStr);
+            return LocalDate.now();
+        }
+    }
+
+    private List<String> getMonthsBetween(LocalDate start, LocalDate end) {
+        List<String> months = new ArrayList<>();
+        LocalDate current = start.withDayOfMonth(1);
+        LocalDate limit = end.withDayOfMonth(1);
+
+        while (!current.isAfter(limit)) {
+            months.add(current.format(DateTimeFormatter.ofPattern("yyyy-MM")));
+            current = current.plusMonths(1);
+        }
+        return months;
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/schedule/entity/scheduleEnum/ScheduleType.java
+++ b/src/main/java/com/mcn/in4/domain/schedule/entity/scheduleEnum/ScheduleType.java
@@ -1,12 +1,22 @@
 package com.mcn.in4.domain.schedule.entity.scheduleEnum;
 
 public enum ScheduleType {
-    COMPANY, //회사
-    PERSONAL, //개인
-    CONTENT, //콘텐츠
-    LIVE, //라이브
-    MEETING, //미팅
-    MERGE, //합방
-    PROMOTION, //광고
-    ETC //기타
+    COMPANY("회사"),
+    PERSONAL("개인"),
+    CONTENT("콘텐츠"),
+    LIVE("라이브"),
+    MEETING("미팅"),
+    MERGE("합방"),
+    PROMOTION("광고"),
+    ETC("기타");
+
+    private final String description;
+
+    ScheduleType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #253 


## 변경 내용
- 챗봇으로 나의 일정, 크리에이터 일정을 조회할 수 있도록 추가했습니다. 
- 각 권한마다 적용되며, 새로운 일정도 반영하여 검색 결과를 알려줍니다.

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수