### PR TITLE
feat: 채팅 프로필 연동

### DIFF
--- a/src/main/java/com/mcn/in4/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/chat/service/ChatServiceImpl.java
@@ -70,7 +70,7 @@ public class ChatServiceImpl implements ChatService {
 
         for (Member member : members) {
             ChatRoomMember roomMember = ChatRoomMember.create(chatRoom, member);
-            chatRoom.addMember(roomMember); // CascadeType.ALL 덕분에 chatRoom 저장 시 함께 저장됨
+            chatRoom.addMember(roomMember);
         }
         // 저장
         chatRoomRepository.save(chatRoom);

--- a/src/main/java/com/mcn/in4/domain/member/dto/MemberSummaryDto.java
+++ b/src/main/java/com/mcn/in4/domain/member/dto/MemberSummaryDto.java
@@ -15,8 +15,9 @@ public class MemberSummaryDto {
     private String task;
     private MemberRole memberRole;
     private MemberStatus memberStatus;
+    private String profileImage;
 
-    public static MemberSummaryDto from(Member member) {
+    public static MemberSummaryDto from(Member member, String profileImage) {
         return MemberSummaryDto.builder()
                 .memberId(member.getMemberId())
                 .departmentName(member.getDepartment() != null ? member.getDepartment().getDepartmentName() : "크리에이터")
@@ -24,6 +25,7 @@ public class MemberSummaryDto {
                 .task(member.getTask())
                 .memberRole(member.getMemberRole())
                 .memberStatus(member.getMemberStatus())
+                .profileImage(profileImage)
                 .build();
     }
 

--- a/src/main/java/com/mcn/in4/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/member/service/MemberServiceImpl.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -94,9 +95,28 @@ public class MemberServiceImpl implements MemberService {
         // 멤버 +부서 간단 정보 가저오는
         @Override
         public List<MemberSummaryDto> getAllMembers() {
-                return memberRepository.findAllWithDepartment().stream()
-                                .map(MemberSummaryDto::from)
-                                .collect(Collectors.toList());
+
+                List<Member> members = memberRepository.findAllWithDepartment();
+
+                List<MemberProfile> profiles = memberProfileRepository.findAll();
+
+                Map<Long,String> profileMap = profiles.stream()
+                        .collect(Collectors.toMap(
+                                p->p.getMember().getMemberId(),
+//                                p-> "https://" + bucket + ".s3." + region
+//                                + ".amazonaws.com/" + p.getProfileImage() //S3에 이미지 파일이 올라갔을때 사용하는게 좋을것같음. 지금은 호스팅 된 웹 링크로 대체
+                                p-> p.getProfileImage()
+                        ));
+
+
+
+                return members.stream()
+                        .map(member -> MemberSummaryDto
+                                .from(
+                                member,
+                                profileMap.getOrDefault(member.getMemberId(), null) // 프로필 없으면 null
+                        ))
+                        .collect(Collectors.toList());
         }
 
         public MemberProfileResponseDto generatePresignedUrl(Long memberId, MultipartFile file) {


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #240 


## 변경 내용
- mebmerprofile repository 프로필과 멤버 조회 
- 채팅 하기 시 직원 리스트를 뿌려줄때 프로필 사진 컬럼을 DTO에 추가 
- 현재 S3가 아닌 더미데이터 링크를 뿌려주는 식으로 작성 


## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수