### PR TITLE
Feat/255 qa board fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
+
+    //email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mcn/in4/In4Application.java
+++ b/src/main/java/com/mcn/in4/In4Application.java
@@ -2,6 +2,7 @@ package com.mcn.in4;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication

--- a/src/main/java/com/mcn/in4/config/JavaMailConfig.java
+++ b/src/main/java/com/mcn/in4/config/JavaMailConfig.java
@@ -1,0 +1,55 @@
+package com.mcn.in4.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class JavaMailConfig {
+    @Value("${mail.host}")
+    private String host;
+
+    @Value("${mail.port}")
+    private int port;
+
+    @Value("${mail.username}")
+    private String username;
+
+    @Value("${mail.password}")
+    private String password;
+
+    @Value("${mail.protocol}")
+    private String protocol;
+
+    @Value("${mail.properties.mail.smtp.auth}")
+    private String auth;
+
+    @Value("${mail.properties.mail.smtp.starttls.enable}")
+    private String enable;
+
+    @Value("${mail.debug}")
+    private String debug;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", enable);
+        props.put("mail.transport.protocol", protocol);
+        props.put("mail.debug", debug);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/QnA/controller/QAController.java
+++ b/src/main/java/com/mcn/in4/domain/QnA/controller/QAController.java
@@ -37,7 +37,7 @@ public class QAController {
     @ResponseBody
     public ResponseEntity<Void> uploadQuestion(
             @AuthenticationPrincipal String userId,
-            QuestionDto request){
+            @RequestBody QuestionDto request){
         Long memberId = Long.parseLong(userId);
         String questionTitle = request.getQuestionTitle();
         String questionDetail = request.getQuestionDetail();
@@ -49,7 +49,7 @@ public class QAController {
     @ResponseBody
     public ResponseEntity<Void> uploadAnswer(
             @AuthenticationPrincipal String userId,
-            AnswerDto request){
+            @RequestBody AnswerDto request){
         Long memberId = Long.parseLong(userId);
         Long qaId = request.getQaId();
         String answerDetail = request.getAnswerDetail();

--- a/src/main/java/com/mcn/in4/domain/QnA/dto/QAResponseDto.java
+++ b/src/main/java/com/mcn/in4/domain/QnA/dto/QAResponseDto.java
@@ -31,12 +31,13 @@ public class QAResponseDto {
         private String questionTitle;
         private LocalDateTime questionTime;
         private String questionMemberName;
-        private String departmentName;
+        private String questionDepartmentName;
         private String questionDetail;
         private boolean answered;
 
         private LocalDateTime answerTime;
         private String answerMemberName;
+        private String answerDepartmentName;
         private String answerDetail;
     }
 }

--- a/src/main/java/com/mcn/in4/domain/QnA/service/MailService.java
+++ b/src/main/java/com/mcn/in4/domain/QnA/service/MailService.java
@@ -1,0 +1,42 @@
+package com.mcn.in4.domain.QnA.service;
+
+import com.mcn.in4.domain.department.entity.Department;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    @Value("${mail.username}")
+    private String username;
+
+    private final JavaMailSender mailSender;
+
+    public void sendUpQuest(String title, String memberName, String departmentName, String content) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(username);
+        message.setSubject("[문의] : " + title);
+        message.setText("[문의자:"+ memberName + " / 문의부서:" + departmentName + "]\n" + content);
+        message.setFrom(username);
+
+        mailSender.send(message);
+    }
+
+    public void sendUpAnswer(String toMail, String title,
+                             String memberName, String departmentName,
+                             String quest, String answer) {
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toMail);
+        message.setSubject("[답변] : " + title);
+        message.setText("[문의사항]\n" + quest + "\n\n" +
+                "[답변자:" + memberName + " / 답변부서:" + departmentName + "]\n"
+                + answer );
+        message.setFrom(username);
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/mcn/in4/domain/QnA/service/QAServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/QnA/service/QAServiceImpl.java
@@ -3,8 +3,11 @@ package com.mcn.in4.domain.QnA.service;
 import com.mcn.in4.domain.QnA.entity.QABoard;
 import com.mcn.in4.domain.QnA.repository.QARepository;
 import com.mcn.in4.domain.member.entity.Member;
+import com.mcn.in4.domain.member.entity.MemberEmployeeDetail;
+import com.mcn.in4.domain.member.repository.MemberEmployeeDetailRepository;
 import com.mcn.in4.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.mcn.in4.domain.QnA.dto.QAResponseDto.*;
@@ -20,6 +23,8 @@ import java.util.Optional;
 public class QAServiceImpl implements QAService{
     private final QARepository qaRepository;
     private final MemberRepository memberRepository;
+    private final MemberEmployeeDetailRepository memberEmployeeDetailRepository;
+    private final MailService mailService;
 
     @Override
     public List<QATitle> generateQATitleList(Long memberId){
@@ -78,6 +83,7 @@ public class QAServiceImpl implements QAService{
                 .questionTime(LocalDateTime.now())
                 .build();
 
+        mailService.sendUpQuest(questionTitle, questionMember.getMemberName(), questionMember.getDepartment().getDepartmentName(), questionDetail);
         qaRepository.save(qaBoard);
     }
 
@@ -85,6 +91,11 @@ public class QAServiceImpl implements QAService{
     public void uploadAnswer(Long memberId, Long qaId, String answerDetail){
         Member answerMember = memberRepository.findById(memberId).orElseThrow();
         QABoard qaBoard = qaRepository.findByQAId(qaId).orElseThrow();
+        MemberEmployeeDetail questionMemberDetail = memberEmployeeDetailRepository.findByMemberMemberId(qaBoard.getQuestionMember().getMemberId()).orElseThrow();
+
+        mailService.sendUpAnswer(questionMemberDetail.getPersonalEmail(), qaBoard.getQuestionTitle(),
+                                answerMember.getMemberName(), answerMember.getDepartment().getDepartmentName(),
+                                qaBoard.getQuestionTitle(), answerDetail);
 
         qaBoard.setAnswerMember(answerMember);
         qaBoard.setAnswerDetail(answerDetail);

--- a/src/main/java/com/mcn/in4/domain/QnA/service/QAServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/QnA/service/QAServiceImpl.java
@@ -51,7 +51,7 @@ public class QAServiceImpl implements QAService{
                 .questionTitle(qaBoard.getQuestionTitle())
                 .questionTime(qaBoard.getQuestionTime())
                 .questionMemberName(qaBoard.getQuestionMember().getMemberName())
-                .departmentName(qaBoard.getQuestionMember().getDepartment() != null
+                .questionDepartmentName(qaBoard.getQuestionMember().getDepartment() != null
                         ? qaBoard.getQuestionMember().getDepartment().getDepartmentName()
                         : "부서없음")
                 .questionDetail(qaBoard.getQuestionDetail())
@@ -60,6 +60,9 @@ public class QAServiceImpl implements QAService{
                 .answerMemberName(qaBoard.getAnswerMember() != null
                         ? qaBoard.getAnswerMember().getMemberName()
                         : null)
+                .answerDepartmentName(qaBoard.getAnswerMember() != null
+                        ? qaBoard.getAnswerMember().getDepartment().getDepartmentName()
+                        :null)
                 .answerDetail(qaBoard.getAnswerDetail())
                 .build();
     }

--- a/src/main/java/com/mcn/in4/domain/member/repository/MemberEmployeeDetailRepository.java
+++ b/src/main/java/com/mcn/in4/domain/member/repository/MemberEmployeeDetailRepository.java
@@ -18,7 +18,6 @@ public interface MemberEmployeeDetailRepository extends JpaRepository<MemberEmpl
     @Query("SELECT e.member.memberId FROM MemberEmployeeDetail e")
     List<Long> findEmployeeIds();
 
-
     //여러 회원의 상세 정보를 한 번에 조회 (IN 절)
     List<MemberEmployeeDetail> findByMemberMemberIdIn(List<Long> memberIds);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -77,9 +77,9 @@ INSERT INTO members (member_id, department_id, member_account, member_password, 
 -- 4. Employee Detail (직원 상세) - task, department_id 제거됨
 -- ==========================================
 INSERT INTO employee_detail (employee_detail_id, employee_id, nickname, eng_name, personal_email, corpor_email, personal_call, hire_date, emp_date, address, employment_type, leaving_reason, vacation_remainder) VALUES
-(1001, 1001, '인사왕', 'Kim Insa', 'kim.insa@gmail.com', 'kim.insa@mcn.com', '010-1111-1111', '2020-03-02', NULL, '서울시 강남구 테헤란로 123', 'EXPERIENCED', NULL, 15.0),
+(1001, 1001, '인사왕', 'Kim Insa', 'rockhavesoul@gmail.com', 'kim.insa@mcn.com', '010-1111-1111', '2020-03-02', NULL, '서울시 강남구 테헤란로 123', 'EXPERIENCED', NULL, 15.0),
 (1002, 1002, '채용마스터', 'Lee Chaeyong', 'lee.chaeyong@naver.com', 'lee.chaeyong@mcn.com', '010-2222-2222', '2021-06-15', NULL, '서울시 서초구 서초대로 456', 'NEWBIE', NULL, 15.0),
-(1003, 1003, '매니저박', 'Park Manager', 'park.mg@gmail.com', 'park.manager@mcn.com', '010-3333-3333', '2019-01-10', NULL, '서울시 마포구 월드컵로 789', 'EXPERIENCED', NULL, 15.0),
+(1003, 1003, '매니저박', 'Park Manager', 'kuroiwadeath@gmail.com', 'park.manager@mcn.com', '010-3333-3333', '2019-01-10', NULL, '서울시 마포구 월드컵로 789', 'EXPERIENCED', NULL, 15.0),
 (1004, 1004, '최담당님', 'Choi Damdang', 'choi.dd@kakao.com', 'choi.damdang@mcn.com', '010-4444-4444', '2022-09-01', NULL, '경기도 성남시 분당구 판교역로 111', 'NEWBIE', NULL, 15.0),
 (1005, 1005, '정매니저', 'Jung Gwanli', 'jung.gl@gmail.com', 'jung.gwanli@mcn.com', '010-5555-5555', '2020-11-20', NULL, '인천시 연수구 송도과학로 222', 'EXPERIENCED', NULL, 15.0),
 (1006, 1006, '강마케터', 'Kang Marketing', 'kang.mk@naver.com', 'kang.marketing@mcn.com', '010-6666-6666', '2021-03-15', NULL, '서울시 영등포구 여의대로 333', 'NEWBIE', NULL, 15.0),


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #255


## 변경 내용
- 이제 QA 게시판으로 문의를 할 수 있습니다.
- 이제 관리자는 답변도 할 수 있습니다.
- 이메일은 MG001, HR001 에서만 정상 작동합니다. (나머지가 더미라)

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수