### PR TITLE
feat: 채팅 페이징처리 스크롤 시 이전 메세지 요청

### DIFF
--- a/src/main/java/com/mcn/in4/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/mcn/in4/domain/chat/controller/ChatController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.List;
 import java.util.stream.Collectors;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -29,20 +30,20 @@ public class ChatController {
     @MessageMapping("/chat/message")
     public void message(ChatMessageDto message, Principal principal) {
 
-         if (principal != null) {
+        if (principal != null) {
 
-             try{
-                 message.setSenderId(Long.parseLong(principal.getName()));
-             }catch (NumberFormatException e) {
-                 log.error("principal 에서 이름을 찾지못함", e);
-             }
-         }
+            try {
+                message.setSenderId(Long.parseLong(principal.getName()));
+            } catch (NumberFormatException e) {
+                log.error("principal 에서 이름을 찾지못함", e);
+            }
+        }
 
         // 입장 메시지 처리
         if (ChatMessageDto.MessageType.ENTER.equals(message.getType())) {
             message.setMessage(message.getSender() + "님이 입장하셨습니다.");
         }
-        //퇴장 메세지
+        // 퇴장 메세지
         if (ChatMessageDto.MessageType.EXIT.equals(message.getType())) {
             message.setMessage(message.getSender() + "님이 퇴장하셨습니다.");
         }
@@ -79,34 +80,44 @@ public class ChatController {
         return chatService.findMyRooms(memberId);
     }
 
-    /// 특정 채팅방의 지난 대화 내용 조회
+    // 처음 들어갔을때 20개 조회
     @GetMapping("/chat/room/{roomId}/messages")
     @ResponseBody
-    public List<ChatMessageDto> getMessages(@PathVariable String roomId, @AuthenticationPrincipal String memberIdStr) {
-
-        Long memberId = Long.parseLong(memberIdStr);
-
-
-        return chatService.findMessages(roomId, memberId);
-
+    public List<ChatMessageDto> getMessages(@PathVariable String roomId, @AuthenticationPrincipal String userId) {
+        Long memberId = Long.parseLong(userId);
+        return chatService.findMessages(roomId, memberId, 20);
     }
 
-    //채팅방 이름 수정
+    // 이전 메세지 조회
+    @GetMapping("/chat/room/{roomId}/messages/older")
+    @ResponseBody
+    public List<ChatMessageDto> getOlderMessages(
+            @PathVariable String roomId,
+            @RequestParam(required = false) Long lastId,
+            @RequestParam(defaultValue = "20") int size) {
+
+        // 데이터가 없을 경우 에러 방지 처리
+        if (lastId == null) {
+            return new java.util.ArrayList<>();
+        }
+
+        return chatService.findOlderMessages(roomId, lastId, size);
+    }
+
+    // 채팅방 이름 수정
     @PatchMapping("/chat/room/{roomId}/name")
     @ResponseBody
     public void updateRoomName(@PathVariable String roomId, @RequestBody ChatRoomCreateRequest request) {
         chatService.updateRoomName(roomId, request.getName());
     }
 
-    //채팅방 나가기
+    // 채팅방 나가기
     @DeleteMapping("/chat/room/{roomId}/leave")
     @ResponseBody
-    public void leaveRoom(@PathVariable String roomId, @AuthenticationPrincipal String userId){
+    public void leaveRoom(@PathVariable String roomId, @AuthenticationPrincipal String userId) {
         Long memberId = Long.parseLong(userId);
         chatService.leaveRoom(roomId, memberId);
-        
+
     }
-
-
 
 }

--- a/src/main/java/com/mcn/in4/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/mcn/in4/domain/chat/dto/ChatMessageDto.java
@@ -16,17 +16,19 @@ public class ChatMessageDto {
         ENTER, TALK, EXIT, MATCH, MATCH_REQUEST, READ;
     }
 
+    private Long id; // 메시지 고유 ID
     private MessageType type; // 메시지 타입
     private String roomId; // 방 번호
     private String sender; // 보낸 사람
-    private Long senderId;//보낸사람 아이디
+    private Long senderId; // 보낸사람 아이디
     private String message; // 메시지 내용
-    private Long unreadCount; //읽지않은 수
+    private Long unreadCount; // 읽지않은 수
 
     private LocalDateTime sendDate;
 
     public static ChatMessageDto from(ChatMessage entity) {
         return ChatMessageDto.builder()
+                .id(entity.getId())
                 .type(MessageType.valueOf(entity.getType().name()))
                 .roomId(entity.getChatRoom().getRoomId())
                 .sender(entity.getSender())

--- a/src/main/java/com/mcn/in4/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mcn/in4/domain/chat/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.mcn.in4.domain.chat.repository;
 
 import com.mcn.in4.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     List<ChatMessage> findAllByRoomIdWithRoom(@Param("roomId") String roomId);
 
     List<ChatMessage> findByChatRoom_RoomIdOrderBySendDateAsc(String roomId);
+
+    // 최신 메시지 조회 처음 들어갔을때
+    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId ORDER BY m.id DESC")
+    List<ChatMessage> findLatestMessages(@Param("roomId") String roomId, Pageable pageable);
+    // 특정 ID보다 작은 메시지 조회 스크롤 업 했을떄
+    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId AND m.id < :lastId ORDER BY m.id DESC")
+    List<ChatMessage> findOlderMessages(@Param("roomId") String roomId, @Param("lastId") Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/mcn/in4/domain/chat/service/ChatService.java
+++ b/src/main/java/com/mcn/in4/domain/chat/service/ChatService.java
@@ -23,8 +23,11 @@ public interface ChatService {
     // 메시지 저장
     ChatMessage saveMessage(ChatMessageDto messageDto);
 
-    // 특정 방의 이전 대화 내역 조회
-    List<ChatMessageDto> findMessages(String roomId, Long memberId);
+    // 처음 들어갔을때 조회
+    List<ChatMessageDto> findMessages(String roomId, Long memberId, int size);
+
+    // 이전 메세지 조회
+    List<ChatMessageDto> findOlderMessages(String roomId, Long lastId, int size);
 
     void updateRoomName(String roomId, String name);
 

--- a/src/main/java/com/mcn/in4/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/chat/service/ChatServiceImpl.java
@@ -15,6 +15,8 @@ import com.mcn.in4.global.error.exception.ErrorCode;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpSubscription;
@@ -70,7 +72,6 @@ public class ChatServiceImpl implements ChatService {
                 .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
     }
 
-    @Override
     @Transactional
     public ChatRoomResponseDto createRoom(String name, List<Long> memberIds) {
         // 채팅방 생성
@@ -188,30 +189,53 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public List<ChatMessageDto> findMessages(String roomId, Long memberId) {
-        //  메시지 & 채팅방 한 번에 조회 (JOIN FETCH)
-        List<ChatMessage> messages = chatMessageRepository.findAllByRoomIdWithRoom(roomId);
+    public List<ChatMessageDto> findMessages(String roomId, Long memberId, int size) {
+        // 처음 들어갔을때 20개 조회
+        Pageable pageable = PageRequest.of(0, size);
+        List<ChatMessage> messages = chatMessageRepository.findLatestMessages(roomId, pageable);
+
         if (messages.isEmpty()) {
             return new ArrayList<>();
         }
 
-        //  채팅방 모든 멤버 & 상세정보 한 번에 조회 (JOIN FETCH)
-        List<ChatRoomMember> allMembers = chatRoomMemberRepository.findAllByRoomIdWithMemberAndRoom(roomId);
-        long totalMembers = allMembers.size();
+        // 시간순 정렬
+        Collections.reverse(messages);
 
-        //  내 읽음 상태 업데이트 및 이벤트 발행 (조건부)
+        // 페이지읽음 처리
         ChatMessage lastMessage = messages.get(messages.size() - 1);
-        allMembers.stream()
-                .filter(m -> m.getMember().getMemberId().equals(memberId))
-                .findFirst()
+        updateMyReadStatus(roomId, memberId, lastMessage.getId());
+
+        // 메시지 DTO 변환 및 안읽은 인원 수 계산
+        return convertToDtoWithUnreadCount(roomId, messages);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatMessageDto> findOlderMessages(String roomId, Long lastId, int size) {
+        // 이전 메세지 조회
+        Pageable pageable = PageRequest.of(0, size);
+        List<ChatMessage> messages = chatMessageRepository.findOlderMessages(roomId, lastId, pageable);
+
+        if (messages.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // 시간순 정렬
+        Collections.reverse(messages);
+
+        // 메시지 DTO 변환 및 안읽은 인원 수 계산
+        return convertToDtoWithUnreadCount(roomId, messages);
+    }
+
+    // 페이지읽음 처리
+    private void updateMyReadStatus(String roomId, Long memberId, Long lastMessageId) {
+        chatRoomMemberRepository.findByChatRoom_RoomIdAndMember_MemberId(roomId, memberId)
                 .ifPresent(m -> {
                     Long lastReadId = m.getLastReadMessageId();
-                    Long currentLastId = lastMessage.getId();
+                    if (lastReadId == null || lastReadId < lastMessageId) {
+                        chatRoomMemberRepository.updateMemberLastReadMessage(roomId, memberId, lastMessageId);
 
-                    if (lastReadId == null || lastReadId < currentLastId) {
-                        chatRoomMemberRepository.updateMemberLastReadMessage(roomId, memberId, currentLastId);
-
-                        // READ 이벤트 발행
+                        // 읽음 알림 이벤트 발행
                         ChatMessageDto readEvent = ChatMessageDto.builder()
                                 .type(ChatMessageDto.MessageType.READ)
                                 .roomId(roomId)
@@ -221,8 +245,13 @@ public class ChatServiceImpl implements ChatService {
                         messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, readEvent);
                     }
                 });
+    }
 
-        // 메모리 연산으로 DTO 변환 (N+1 없음)
+    // 메시지 DTO 변환 및 안읽은 인원 수 계산
+    private List<ChatMessageDto> convertToDtoWithUnreadCount(String roomId, List<ChatMessage> messages) {
+        List<ChatRoomMember> allMembers = chatRoomMemberRepository.findAllByRoomIdWithMemberAndRoom(roomId);
+        long totalMembers = allMembers.size();
+
         return messages.stream()
                 .map(msg -> {
                     ChatMessageDto dto = ChatMessageDto.from(msg);
@@ -239,7 +268,7 @@ public class ChatServiceImpl implements ChatService {
     @Override
     public void updateRoomName(String roomId, String name) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(()-> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         chatRoom.updateName(name);
         chatRoomRepository.save(chatRoom);
     }
@@ -248,9 +277,8 @@ public class ChatServiceImpl implements ChatService {
     @Transactional
     public void leaveRoom(String roomId, Long memberId) {
         ChatRoomMember roomMember = chatRoomMemberRepository.findByChatRoom_RoomIdAndMember_MemberId(roomId, memberId)
-                .orElseThrow(()-> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         chatRoomMemberRepository.delete(roomMember);
     }
-
 
 }


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #


## 변경 내용
- 채팅 페이징처리 스크롤 시 이전 메세지 요청
- 채팅 20개씩 페이징 처리 
- 마지막 id 를 기준으로 이전 것 가져오기
## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수