### PR TITLE
fix: 채팅 읽음 처리 오류 수정

### DIFF
--- a/src/main/java/com/mcn/in4/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/mcn/in4/domain/chat/dto/ChatRoomResponseDto.java
@@ -33,7 +33,6 @@ public class ChatRoomResponseDto {
         private Long memberId;
         private String memberName;
 
-
         public static MemberSimpleDto from(Member member) {
             return MemberSimpleDto.builder()
                     .memberId(member.getMemberId())

--- a/src/main/java/com/mcn/in4/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/mcn/in4/domain/chat/entity/ChatRoomMember.java
@@ -6,7 +6,6 @@ import lombok.*;
 import java.time.LocalDateTime;
 import com.mcn.in4.domain.member.entity.Member;
 
-
 @Entity
 @Table(name = "chat_room_member")
 @Getter

--- a/src/main/java/com/mcn/in4/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mcn/in4/domain/chat/repository/ChatMessageRepository.java
@@ -10,15 +10,17 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    @Query("SELECT m FROM ChatMessage m JOIN FETCH m.chatRoom WHERE m.chatRoom.roomId = :roomId ORDER BY m.sendDate ASC")
-    List<ChatMessage> findAllByRoomIdWithRoom(@Param("roomId") String roomId);
+        @Query("SELECT m FROM ChatMessage m JOIN FETCH m.chatRoom WHERE m.chatRoom.roomId = :roomId ORDER BY m.sendDate ASC")
+        List<ChatMessage> findAllByRoomIdWithRoom(@Param("roomId") String roomId);
 
-    List<ChatMessage> findByChatRoom_RoomIdOrderBySendDateAsc(String roomId);
+        List<ChatMessage> findByChatRoom_RoomIdOrderBySendDateAsc(String roomId);
 
-    // 최신 메시지 조회 처음 들어갔을때
-    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId ORDER BY m.id DESC")
-    List<ChatMessage> findLatestMessages(@Param("roomId") String roomId, Pageable pageable);
-    // 특정 ID보다 작은 메시지 조회 스크롤 업 했을떄
-    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId AND m.id < :lastId ORDER BY m.id DESC")
-    List<ChatMessage> findOlderMessages(@Param("roomId") String roomId, @Param("lastId") Long lastId, Pageable pageable);
+        // 최신 메시지 조회 처음 들어갔을때
+        @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId ORDER BY m.id DESC")
+        List<ChatMessage> findLatestMessages(@Param("roomId") String roomId, Pageable pageable);
+
+        // 특정 ID보다 작은 메시지 조회 스크롤 업 했을떄
+        @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId AND m.id < :lastId ORDER BY m.id DESC")
+        List<ChatMessage> findOlderMessages(@Param("roomId") String roomId, @Param("lastId") Long lastId,
+                        Pageable pageable);
 }

--- a/src/main/java/com/mcn/in4/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/mcn/in4/domain/chat/repository/ChatRoomMemberRepository.java
@@ -11,29 +11,29 @@ import java.util.Optional;
 
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, String> {
 
-    @Query("SELECT cm FROM ChatRoomMember cm JOIN FETCH cm.member JOIN FETCH cm.chatRoom WHERE cm.chatRoom.roomId = :roomId")
-    List<ChatRoomMember> findAllByRoomIdWithMemberAndRoom(@Param("roomId") String roomId);
+        @Query("SELECT cm FROM ChatRoomMember cm JOIN FETCH cm.member JOIN FETCH cm.chatRoom WHERE cm.chatRoom.roomId = :roomId")
+        List<ChatRoomMember> findAllByRoomIdWithMemberAndRoom(@Param("roomId") String roomId);
 
-    Optional<ChatRoomMember> findByChatRoom_RoomIdAndMember_MemberId(String roomId, Long memberId);
+        Optional<ChatRoomMember> findByChatRoom_RoomIdAndMember_MemberId(String roomId, Long memberId);
 
-    List<ChatRoomMember> findByChatRoom_RoomId(String roomId);
+        List<ChatRoomMember> findByChatRoom_RoomId(String roomId);
 
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE ChatRoomMember cm SET cm.lastReadMessageId = :lastReadMessageId WHERE cm.chatRoom.roomId = :roomId AND cm.member.memberId = :memberId")
-    void updateMemberLastReadMessage(@Param("roomId") String roomId, @Param("memberId") Long memberId,
-            @Param("lastReadMessageId") Long lastReadMessageId);
+        @Modifying(clearAutomatically = true)
+        @Query("UPDATE ChatRoomMember cm SET cm.lastReadMessageId = :lastReadMessageId WHERE cm.chatRoom.roomId = :roomId AND cm.member.memberId = :memberId")
+        void updateMemberLastReadMessage(@Param("roomId") String roomId, @Param("memberId") Long memberId,
+                        @Param("lastReadMessageId") Long lastReadMessageId);
 
-    // 특정 채팅방 전체 인원수 카운트 쿼리
-    @Query("SELECT COUNT(cm) FROM ChatRoomMember cm WHERE cm.chatRoom.roomId = :roomId")
-    Long countByRoomId(@Param("roomId") String roomId);
+        // 특정 채팅방 전체 인원수 카운트 쿼리
+        @Query("SELECT COUNT(cm) FROM ChatRoomMember cm WHERE cm.chatRoom.roomId = :roomId")
+        Long countByRoomId(@Param("roomId") String roomId);
 
-    // 읽은 사람 수(맨 마지막 읽은 매세지 >= 현재 메세지)
-    @Query("SELECT COUNT(cm) FROM ChatRoomMember cm WHERE cm.chatRoom.roomId = :roomId AND cm.lastReadMessageId >= :messageId")
-    long countReadMembers(@Param("roomId") String roomId, @Param("messageId") Long messageId);
+        // 읽은 사람 수(맨 마지막 읽은 매세지 >= 현재 메세지)
+        @Query("SELECT COUNT(cm) FROM ChatRoomMember cm WHERE cm.chatRoom.roomId = :roomId AND cm.lastReadMessageId >= :messageId")
+        long countReadMembers(@Param("roomId") String roomId, @Param("messageId") Long messageId);
 
-    // 접속중인 즉 구독하고있는 사람들 마지막 읽음 업데이트 벌크 업데이트
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE ChatRoomMember cm SET cm.lastReadMessageId = :lastReadMessageId WHERE cm.chatRoom.roomId = :roomId AND cm.member.memberId IN :memberIds")
-    void updateLastReadMessageId(@Param("roomId") String roomId, @Param("memberIds") List<Long> memberIds,
-            @Param("lastReadMessageId") Long lastReadMessageId);
+        // 접속중인 즉 구독하고있는 사람들 마지막 읽음 업데이트 벌크 업데이트
+        @Modifying(clearAutomatically = true)
+        @Query("UPDATE ChatRoomMember cm SET cm.lastReadMessageId = :lastReadMessageId WHERE cm.chatRoom.roomId = :roomId AND cm.member.memberId IN :memberIds")
+        void updateLastReadMessageId(@Param("roomId") String roomId, @Param("memberIds") List<Long> memberIds,
+                        @Param("lastReadMessageId") Long lastReadMessageId);
 }

--- a/src/main/java/com/mcn/in4/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mcn/in4/domain/chat/repository/ChatRoomRepository.java
@@ -9,19 +9,19 @@ import java.util.List;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
 
-    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
-            "LEFT JOIN FETCH cr.members crm " +
-            "LEFT JOIN FETCH crm.member m " +
-            "LEFT JOIN FETCH m.department " +
-            "ORDER BY cr.createdAt DESC")
-    List<ChatRoom> findAllByOrderByCreatedAtDesc();
+        @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+                        "LEFT JOIN FETCH cr.members crm " +
+                        "LEFT JOIN FETCH crm.member m " +
+                        "LEFT JOIN FETCH m.department " +
+                        "ORDER BY cr.createdAt DESC")
+        List<ChatRoom> findAllByOrderByCreatedAtDesc();
 
-    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
-            "JOIN cr.members m " +
-            "LEFT JOIN FETCH cr.members crm " +
-            "LEFT JOIN FETCH crm.member mem " +
-            "LEFT JOIN FETCH mem.department " +
-            "WHERE m.member.memberId = :memberId " +
-            "ORDER BY cr.createdAt DESC")
-    List<ChatRoom> findAllByMemberId(@Param("memberId") Long memberId);
+        @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
+                        "JOIN cr.members m " +
+                        "LEFT JOIN FETCH cr.members crm " +
+                        "LEFT JOIN FETCH crm.member mem " +
+                        "LEFT JOIN FETCH mem.department " +
+                        "WHERE m.member.memberId = :memberId " +
+                        "ORDER BY cr.createdAt DESC")
+        List<ChatRoom> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/mcn/in4/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/chat/service/ChatServiceImpl.java
@@ -103,28 +103,25 @@ public class ChatServiceImpl implements ChatService {
                 // DTO의 Enum을 Entity의 Enum으로 변환
                 .type(ChatMessage.MessageType.valueOf(messageDto.getType().name()))
                 .build();
-        // 저장
+        // 메세지 저장 및 발신자 읽음 처리
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
 
         String roomId = messageDto.getRoomId();
-        log.info("roomId={}", roomId);
         Long newMessageId = savedMessage.getId();
-        log.info("newMessageId={}", newMessageId);
-        List<Long> connectedMemberIds = findConnectedUsers(roomId);
-        log.info("connectedMemberIds={}", connectedMemberIds);
-        // 접속 멤버들 lastRead 업데이트
-        if (!connectedMemberIds.isEmpty()) {
-            chatRoomMemberRepository.updateLastReadMessageId(roomId, connectedMemberIds, newMessageId);
-        }
+        Long senderId = messageDto.getSenderId();
 
-        // unreadCount 계산
+        // 발신자 및 접속자 읽음 상태 업데이트
+        List<Long> membersToUpdate = new ArrayList<>(findConnectedUsers(roomId));
+        if (!membersToUpdate.contains(senderId)) {
+            membersToUpdate.add(senderId);
+        }
+        chatRoomMemberRepository.updateLastReadMessageId(roomId, membersToUpdate, newMessageId);
+
+        // 안읽은 인원수 계산
         long totalMembers = chatRoomMemberRepository.countByRoomId(roomId);
         long readMembers = chatRoomMemberRepository.countReadMembers(roomId, newMessageId);
 
-        long unreadCount = totalMembers - readMembers;
-        if (unreadCount < 0)
-            unreadCount = 0;
-
+        long unreadCount = Math.max(0, totalMembers - readMembers);
         messageDto.setUnreadCount(unreadCount);
 
         return savedMessage;
@@ -190,7 +187,7 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional
     public List<ChatMessageDto> findMessages(String roomId, Long memberId, int size) {
-        // 처음 들어갔을때 20개 조회
+        // 채팅방 진입 시 메시지 조회
         Pageable pageable = PageRequest.of(0, size);
         List<ChatMessage> messages = chatMessageRepository.findLatestMessages(roomId, pageable);
 
@@ -247,7 +244,7 @@ public class ChatServiceImpl implements ChatService {
                 });
     }
 
-    // 메시지 DTO 변환 및 안읽은 인원 수 계산
+    // 메시지 목록 변환 및 각 메시지별 안읽은 인원수 합산
     private List<ChatMessageDto> convertToDtoWithUnreadCount(String roomId, List<ChatMessage> messages) {
         List<ChatRoomMember> allMembers = chatRoomMemberRepository.findAllByRoomIdWithMemberAndRoom(roomId);
         long totalMembers = allMembers.size();
@@ -256,7 +253,13 @@ public class ChatServiceImpl implements ChatService {
                 .map(msg -> {
                     ChatMessageDto dto = ChatMessageDto.from(msg);
                     long readCount = allMembers.stream()
-                            .filter(m -> m.getLastReadMessageId() != null && m.getLastReadMessageId() >= msg.getId())
+                            .filter(m -> {
+                                // 발신자 본인은 항상 읽음 처리하거나 마지막 읽은 메시지 확인
+                                boolean isSender = m.getMember().getMemberId().equals(msg.getSenderId());
+                                boolean hasRead = m.getLastReadMessageId() != null
+                                        && m.getLastReadMessageId() >= msg.getId();
+                                return isSender || hasRead;
+                            })
                             .count();
                     long unreadCount = totalMembers - readCount;
                     dto.setUnreadCount(Math.max(0, unreadCount));


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #284 


## 변경 내용
- 채팅에서 sender 가 보낸것은 자신이 읽는것이 안되어 숫자가 - 가 안되는 상황 수정

## 리뷰 포인트
- Trade 도메인 의존성 제거 방식 적절한지
- sellerId 중복 저장(성능 목적) 설계 타당성

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수