### PR TITLE
fix: correct date filter in my vacations and vacation management #287

### DIFF
--- a/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
+++ b/src/main/java/com/mcn/in4/domain/vacation/repository/VacationRepository.java
@@ -26,7 +26,7 @@ public interface VacationRepository extends JpaRepository<Vacation, Long>, JpaSp
         /** 내 휴가 목록 조회 (기간, 유형 필터 적용) */
         @Query("SELECT v FROM Vacation v " +
                         "WHERE v.member.memberId = :memberId " +
-                        "AND v.vacationRequest BETWEEN :startDate AND :endDate " +
+                        "AND v.vacationStart BETWEEN :startDate AND :endDate " +
                         "AND (:type IS NULL OR v.vacationType = :type) " +
                         "ORDER BY v.vacationRequest DESC")
         List<Vacation> findMyVacationsWithFilters(
@@ -38,7 +38,7 @@ public interface VacationRepository extends JpaRepository<Vacation, Long>, JpaSp
         /** 내 휴가 목록 조회 - 페이징 적용 (기간, 유형 필터 적용) */
         @Query("SELECT v FROM Vacation v " +
                         "WHERE v.member.memberId = :memberId " +
-                        "AND v.vacationRequest BETWEEN :startDate AND :endDate " +
+                        "AND v.vacationStart BETWEEN :startDate AND :endDate " +
                         "AND (:type IS NULL OR v.vacationType = :type)")
         Page<Vacation> findMyVacationsWithFiltersPaged(
                         @Param("memberId") Long memberId,


### PR DESCRIPTION
## 관련 이슈 번호
- Closes #287

## 내용
- 나의휴가 및 휴가관리 날짜 필터 정상 수정
- 병가, 워케이션, 경조사 필수 입력내역 필수 처리 및 해당 알림 추가
- 휴가 반려사유 작성 알림 추가

## 작업
- 나의휴가 및 휴가관리 날짜 필터가 포함되지 않은 날짜도 노출시키는 문제 확인
- 병가, 워케이션, 경조사 필수 입력내역이 없어도 등록됨