### PR TITLE
fix: 이미지 분석 할 때 gpt-4o-mini 사용하도록 수정 #298

### DIFF
--- a/src/main/java/com/mcn/in4/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/mcn/in4/domain/image/service/ImageServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.model.Media;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeTypeUtils;
@@ -60,7 +61,13 @@ public class ImageServiceImpl implements ImageService {
             );
 
             // AI 호출 및 결과 파싱
-            ChatResponse response = openAiChatModel.call(new Prompt(userMessage));
+            ChatResponse response = openAiChatModel.call(new Prompt(
+                    userMessage,
+                    OpenAiChatOptions.builder()
+                            .model("gpt-4o-mini")
+                            .temperature(0.1)
+                            .build()
+            ));
             String content = response.getResult().getOutput().getText();
 
             // JSON 문자열을 DTO로 변환하여 반환


### PR DESCRIPTION
## 관련 이슈 번호
- #298 


## 변경 내용
이미지 분석 할 때 gpt-4o-mini 사용하도록 수정

## 리뷰 포인트

## 테스트
- 로컬 테스트:
- 로그/스크린샷:


## 체크리스트
- [ ] 빌드/컴파일 정상
- [ ] 로컬 테스트 완료
- [ ] 불필요 코드 제거
- [ ] 브랜치 전략 준수